### PR TITLE
Fix bug to not hardcode the number of expected gifs and youtube videos

### DIFF
--- a/lib/api.py
+++ b/lib/api.py
@@ -36,7 +36,7 @@ class API:
             idx = int(idx)
         except ValueError:
             raise APIError(
-                "```You have to specify an integer if you want " "query by index!```"
+                "```You have to specify an integer if you want query by index!```"
             )
 
         if idx < 0 or idx > max_idx:

--- a/lib/giphy.py
+++ b/lib/giphy.py
@@ -3,7 +3,6 @@ import os
 from lib.api import API
 
 GIPHY_AUTH = os.environ["GIPHY_AUTH"]
-GIPHY_MAX_IDX = 24
 
 
 class Giphy(API):
@@ -20,8 +19,8 @@ class Giphy(API):
 
     def get_gif(self, idx):
         self.validate_num_gifs()
-        print(idx)
-        self.validate_idx(idx, max_idx=GIPHY_MAX_IDX)
+        max_idx = len(self.data["data"])
+        self.validate_idx(idx, max_idx)
         return self.data["data"][idx]["bitly_gif_url"]
 
     @property

--- a/lib/version.py
+++ b/lib/version.py
@@ -1,1 +1,1 @@
-VERSION = "2.4.1"
+VERSION = "2.4.2"

--- a/lib/youtube.py
+++ b/lib/youtube.py
@@ -12,7 +12,8 @@ class Youtube(API):
 
     def get_video(self, idx):
         self.validate_num_vids()
-        self.validate_idx(idx, max_idx=YOUTUBE_MAX_IDX)
+        max_idx = len(self.data["items"])
+        self.validate_idx(idx, max_idx)
 
         return BASE_URL + self.data["items"][idx]["id"]["videoId"]
 


### PR DESCRIPTION
# What/Why
SaltBot was responding incorrectly with certain gif queries as giphy would return more than the hardcoded value. Instead of hardcoding these values, we can just get them from the response itself.

## Additional fixes
 - Took out a useless debug print
 - Found a weird formatting from `black`