### PR TITLE
Added extra check for empty giphy queries

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -273,6 +273,7 @@ class Command:
             ),
         )
 
+    #  pylint: disable=too-many-return-statements
     def gif(self, *args):
         """
             Use the giphy api to query and return one or all gif
@@ -302,6 +303,9 @@ class Command:
 
         except APIError as error:
             return "text", str(error)
+
+        except ValueError:
+            return "text", "```Sorry, there were no gifs for that query :(```"
 
     @staticmethod
     def youtube(*args):

--- a/lib/version.py
+++ b/lib/version.py
@@ -1,3 +1,3 @@
 """ Version file """
 
-VERSION = "2.4.3"
+VERSION = "2.4.4"


### PR DESCRIPTION
# What/Why
Saltbot is not returning anything when giphy responds with no results for the request. Because of that, it makes it seem like Saltbot is unresponsive or degraded. This PR handles that issue and returns: `Sorry, there were no gifs for that query :(` instead.

## What broke?
The traceback of the error is:
```
Traceback (most recent call last):
  File "/home/pi/.local/lib/python3.7/site-packages/discord/client.py", line 312, in _run_event
    await coro(*args, **kwargs)
  File "/home/pi/SaltBot2.0/lib/controller.py", line 30, in on_message
    type_, resp = bot_cmd.commands[cmd](*args)
  File "/home/pi/SaltBot2.0/lib/commands.py", line 300, in gif
    idx = randint(0, giphy.num_gifs - 1) if idx == -1 else idx
  File "/usr/lib/python3.7/random.py", line 222, in randint
    return self.randrange(a, b+1)
  File "/usr/lib/python3.7/random.py", line 200, in randrange
    raise ValueError("empty range for randrange() (%d,%d, %d)" % (istart, istop, width))
ValueError: empty range for randrange() (0,0, 0)
```
Since there were 0 results, there was an empty range to pick a random number from.