### PR TITLE
Allow polls to work in DMs

### DIFF
--- a/saltbot/commands.py
+++ b/saltbot/commands.py
@@ -204,9 +204,6 @@ class Command:
         if len(args) == 0:
             return "text", POLL_HELP_MSG
 
-        if isinstance(self._channel, discord.channel.DMChannel):
-            return "text", "```Polls don't work in DMs :(```"
-
         poll_data["choices"] = [
             phrase.strip() for phrase in self._user_msg.content.split(";")
         ]

--- a/saltbot/version.py
+++ b/saltbot/version.py
@@ -1,3 +1,3 @@
 """ Version file """
 
-VERSION = "2.4.4"
+VERSION = "2.4.5"


### PR DESCRIPTION
# What/Why
I took away SaltBot's ability to do polls in a dm at some point for some reason, but I have no idea why. So I'm allowing SaltBot to work in dms so that folks can test them out first.