### PR TITLE
Fixed poll help bug

### DIFF
--- a/saltbot/commands.py
+++ b/saltbot/commands.py
@@ -204,6 +204,9 @@ class Command:
         if len(args) == 0:
             return "text", POLL_HELP_MSG
 
+        if args[0] == "help":
+            return "text", POLL_HELP_MSG
+
         poll_data["choices"] = [
             phrase.strip() for phrase in self._user_msg.content.split(";")
         ]

--- a/saltbot/version.py
+++ b/saltbot/version.py
@@ -1,3 +1,3 @@
 """ Version file """
 
-VERSION = "2.4.5"
+VERSION = "2.4.6"


### PR DESCRIPTION
# What/Why
I wasn't checking for the first argument to be help and the `split` on ";" was making it where there were not enough arguments for the index I was doing later on. This PR checks explicitly for the `help` and returns the help massage to the user.