### PR TITLE
Add Reminders to SaltBot

### DIFF
--- a/saltbot/commands.py
+++ b/saltbot/commands.py
@@ -127,7 +127,7 @@ class Command:
             return "text", REMINDER_HELP_MSG
 
         try:
-            reminder = Reminder(self._full_user, *args)
+            reminder = Reminder(self._full_user, self._channel.id, *args)
             return "text", reminder.execute()
 
         except ReminderError as error:

--- a/saltbot/commands.py
+++ b/saltbot/commands.py
@@ -10,6 +10,7 @@ import requests
 from api import APIError
 from giphy import Giphy
 from poll import Poll, POLL_HELP_MSG
+from reminder import Reminder, ReminderError, REMINDER_HELP_MSG
 from timelength import TimeLength
 from version import VERSION
 from youtube import Youtube
@@ -34,6 +35,7 @@ MSG_DICT = {
     "!poll (!p)": 'Type "!poll help" for detailed information',
     "!vote (!v)": 'Vote in a poll. Type "!vote <poll id> <poll choice>" to cast your vote',
     "!youtube (!y)": "Get a youtube search result. Use the '-i' parameter to specify an index",
+    "!remind (!r)": 'Set a reminder. Type "remind help" for detailed information',
 }
 
 
@@ -92,6 +94,8 @@ class Command:
             "!p": self.poll,
             "!youtube": self.youtube,
             "!y": self.youtube,
+            "!remind": self.remind,
+            "r": self.remind,
         }
 
     def help(self):
@@ -114,6 +118,20 @@ class Command:
         )
 
         return "text", ret_msg
+
+    def remind(self, *args):
+        """
+        Set a reminder
+        """
+        if len(args) == 0 or args[0] == "help":
+            return "text", REMINDER_HELP_MSG
+
+        try:
+            reminder = Reminder(self._full_user, *args)
+            return "text", reminder.execute()
+
+        except ReminderError as error:
+            return "text", str(error)
 
     def vote(self, *args):
         """

--- a/saltbot/controller.py
+++ b/saltbot/controller.py
@@ -6,6 +6,7 @@ import discord
 from commands import Command
 from logger import Logger
 from poll import monitor_polls
+from reminder import monitor_reminders
 
 LOGGER = Logger()
 CLIENT = discord.Client()
@@ -55,4 +56,6 @@ async def on_ready():
     LOGGER.log(CLIENT.user.name)
     LOGGER.log(str(CLIENT.user.id))
     await CLIENT.change_presence(activity=discord.Game(name="The Salt Shaker"))
-    CLIENT.loop.create_task(monitor_polls(CLIENT))
+
+    for coroutine in (monitor_polls, monitor_reminders):
+        CLIENT.loop.create_task(coroutine(CLIENT))

--- a/saltbot/controller.py
+++ b/saltbot/controller.py
@@ -25,8 +25,9 @@ async def on_message(msg):
                 f"```Hello. I'm sorry I don't understand {cmd}. Please type "
                 '"!help" to see a list of available commands\n```'
             )
+            return
 
-        else:
+        try:
             type_, resp = bot_cmd.commands[cmd](*args)
             LOGGER.log_sent(msg.author, msg.channel, cmd)
 
@@ -39,9 +40,10 @@ async def on_message(msg):
                     await msg.channel.send(item)
             elif type_ == "user":
                 await msg.author.send(resp)
-            else:
-                err_msg = "```Unexpected error :(```"
-                await msg.channel.send(err_msg)
+
+        except Exception:  #  pylint: disable=broad-except
+            traceback.print_exc()
+            await msg.channel.send("```Unexpected error :(```")
 
 
 @CLIENT.event

--- a/saltbot/controller.py
+++ b/saltbot/controller.py
@@ -1,4 +1,6 @@
 """ Controller module for handling coroutines """
+import traceback
+
 import discord
 
 from commands import Command

--- a/saltbot/poll.py
+++ b/saltbot/poll.py
@@ -9,36 +9,116 @@ import time
 POLL_DIR = os.path.join(str(Path.home()), ".config/saltbot/polls")
 os.makedirs(POLL_DIR, exist_ok=True)
 
+POLL_HELP_MSG = (
+    "```How to set a poll:\nType the !poll command followed by the question, the "
+    "answers, and the time all separated by semicolons. For Example:\n\n "
+    "!poll How many times do you poop daily? ; Less than once ; Once ; Twice ; "
+    "More than twice ; ends in 4 hours\n\nThe final poll expiry has to be in "
+    'the format "ends in X Y" where "X" is any positive integer and "Y" '
+    "is one of (hours, hour, minutes, minute, seconds, second)```"
+)
+
+
+class Poll:
+    """ Poll class """
+
+    def __init__(self, **kwargs):
+        self._expiry = None
+        self._poll_id = None
+        self._time_length = kwargs.get("time_length")
+        if self._time_length:
+            self._expiry = self._time_length.timeout
+            self._poll_id = self._time_length.unique_id
+
+        # Default to no choices
+        self.choices = kwargs.get("choices", 0)
+        self.votes = kwargs.get("votes")
+
+        self.prompt = kwargs.get("prompt")
+        self.channel_id = kwargs.get("channel_id")
+
+    @property
+    def poll_id(self):
+        """ poll_id read only property """
+        return self._poll_id
+
+    @property
+    def expiry(self):
+        """ Read only poll expiry """
+        return self._expiry
+
+    def save(self):
+        """ Save the poll to disk """
+        data = {
+            "prompt": self.prompt,
+            "choices": self.choices,
+            "expiry": self._expiry,
+            "poll_id": self._poll_id,
+            "channel_id": self.channel_id,
+            "votes": self.votes,
+        }
+        with open(f"{POLL_DIR}/{self._poll_id}.json", "w") as stream:
+            stream.write(json.dumps(data))
+
+    def load(self, poll_id):
+        """ Load the data from disk """
+        with open(f"{POLL_DIR}/{poll_id}.json") as stream:
+            data = json.load(stream)
+
+        try:
+            self.prompt = data["prompt"]
+            self.choices = data["choices"]
+            self._expiry = data["expiry"]
+            self._poll_id = data["poll_id"]
+            self.channel_id = data["channel_id"]
+            self.votes = data["votes"]
+        except KeyError as error:
+            raise ValueError(
+                "```Something went wrong with poll {poll_id}```"
+            ) from error
+
+    def delete(self):
+        """ Delete the poll """
+        # Poll ID has to exist to be able to delete a poll
+        assert self._poll_id is not None
+        try:
+            os.remove(f"{POLL_DIR}/{self._poll_id}.json")
+        except FileNotFoundError:
+            print("Warning: {self._poll_id} does not exist!")
+
 
 async def monitor_polls(discord_client):
     """ Check poll files for expiry every 5 seconds """
     while True:
-        polls = glob.glob(f"{POLL_DIR}/*")
-        for poll in polls:
-            with open(poll) as stream:
-                poll_data = json.loads(stream.read())
-            if time.time() > poll_data["expiry"]:
-                channel = discord_client.get_channel(poll_data["channel_id"])
+        poll = Poll()
+        poll_files = glob.glob(f"{POLL_DIR}/*")
+        for poll_file in poll_files:
+            # Get the ID from the file name
+            poll_id = os.path.splitext(poll_file)[0].split("/")[-1]
+            poll.load(poll_id)
+
+            if time.time() > poll.expiry:
+                channel = discord_client.get_channel(poll.channel_id)
                 total_votes = 0
                 results = {}
-                for choice_num in range(len(poll_data["choices"])):
-                    total_for_this_choice = len(poll_data["votes"][str(choice_num)])
+                for choice_num in range(len(poll.choices)):
+                    total_for_this_choice = len(poll.votes[str(choice_num)])
                     results[choice_num] = total_for_this_choice
                     total_votes += total_for_this_choice
 
                 response = f"```Results (Total votes: {total_votes}):\n\n"
                 try:
                     for result in results:
-                        choice = poll_data["choices"][result]
+                        choice = poll.choices[result]
                         response += (
                             f"\t{choice} -> "
-                            f"{float(len(poll_data['votes'][str(result)])/total_votes) * 100:.0f}"
+                            f"{float(len(poll.votes[str(result)])/total_votes) * 100:.0f}"
                             "%\n"
                         )
                 except ZeroDivisionError:
                     response = "```No one voted on this poll :("
 
                 await channel.send(f"{response}```")
-                os.remove(poll)
+                poll.delete()
 
         await asyncio.sleep(5)

--- a/saltbot/reminder.py
+++ b/saltbot/reminder.py
@@ -1,0 +1,174 @@
+"""
+    Reminder class for handing reminders
+"""
+from datetime import datetime
+import glob
+import json
+import os
+from pathlib import Path
+
+from timelength import TimeLength
+
+REMINDER_DIR = os.path.join(str(Path.home()), ".config/saltbot/reminders")
+os.makedirs(REMINDER_DIR, exist_ok=True)
+
+REMINDER_HELP_MSG = (
+    '```Set a reminder, show reminders or delete a reminder.\n\nTo set one:\n"!remind set finish '
+    'fixing saltot bugs ends in 4 hours"\n\nTo show all reminders:\n"!remind show"\n\nTo delete:'
+    '\n"!remind delete <ID>"\n\nTo delete a reminder, you need to know the ID. The "!remind show "'
+    "command lists all your reminders and IDs```"
+)
+
+
+class ReminderError(Exception):
+    """ Raised when there is an issue with a reminder operation """
+
+
+class ReminderFile(dict):
+    """ Reminder File Object to Read and Write from memory """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        path = kwargs.pop("path")
+
+        self.msg = kwargs.get("msg")
+        self.unique_id = kwargs.get("unique_id")
+        self.timeout = kwargs.get("timeout")
+        self._path = f"{path}/{self.unique_id}.json"
+
+        if os.path.exists(self._path):
+            self._read()
+
+    def __str__(self):
+        formatted_time = datetime.fromtimestamp(self.timeout).strftime(
+            "%b %d, %Y at %I:%M:%S %p"
+        )
+        return f'{self.unique_id}: "{self.msg}" at {formatted_time}'
+
+    def write(self):
+        """ Write a reminder to disk """
+        with open(self._path, "w") as stream:
+            stream.write(json.dumps(self))
+
+    def delete(self):
+        """ Delete a reminder from disk """
+        try:
+            os.remove(self._path)
+        except FileNotFoundError as error:
+            raise ReminderError(
+                "```That reminder ID does not exist! :o\n"
+                'Type "!remind show" to see all your reminders```'
+            ) from error
+
+    def _read(self):
+        with open(self._path) as stream:
+            data = json.load(stream)
+
+        self.msg = data["msg"]
+        self.unique_id = data["unique_id"]
+        self.timeout = data["timeout"]
+
+
+class ReminderFileHandler:
+    """ File Finder/Handler """
+
+    def __init__(self, user):
+        self._user = user
+        self.path = f"{REMINDER_DIR}/{user}"
+        os.makedirs(self.path, exist_ok=True)
+
+    def load(self, reminder_id):
+        """ Load an existing reminder by id """
+        return ReminderFile(path=self.path, unique_id=reminder_id)
+
+    def write(self, **kwargs):
+        """ Write a reminder to disk and return the object """
+        kwargs["path"] = self.path
+        reminder_file = ReminderFile(**kwargs)
+        reminder_file.write()
+        return str(reminder_file)
+
+    @property
+    def reminders(self):
+        """ Get all reminders for a specified user """
+        reminders = []
+        files = glob.glob(f"{self.path}/*")
+        for file_ in files:
+            unique_id = os.path.splitext(file_)[0].split("/")[-1]
+            reminders.append(ReminderFile(path=self.path, unique_id=unique_id))
+
+        return reminders
+
+
+class Reminder:
+    """ Reminder class """
+
+    def __init__(self, user, *args):
+        # Convert the tuple to a list
+        self._args = list(args)
+
+        self._user = user
+        self._cmd = self._args.pop(0)
+
+    def execute(self):
+        """ Parse through the reminder and set appropriate instance vars """
+        if self._cmd.lower() == "set":
+            try:
+                unit = self._args.pop(-1)
+                amount_of_time = self._args.pop(-1)
+
+                # Remove "ends" and "in"
+                for word in ("ends", "in"):
+                    self._args.remove(word)
+
+                return self.set_reminder(unit, amount_of_time, msg=" ".join(self._args))
+
+            except IndexError as error:
+                raise ReminderError(
+                    "```Reninder time must be in format <amount> <unit> (ex 5 minutes)```"
+                ) from error
+
+        if self._cmd.lower() == "show":
+            return self.show_reminders()
+
+        if self._cmd.lower() == "delete":
+            reminder_id = self._args.pop(-1)
+            return self.delete(reminder_id)
+
+        raise ReminderError(
+            f"```Invalid command {self._cmd}\nValid commands: ('set', 'show', 'delete')```"
+        )
+
+    def set_reminder(self, unit, amount_of_time, msg):
+        """ Write a reminder to disk """
+        try:
+            time_length = TimeLength(unit, amount_of_time)
+        except ValueError as error:
+            raise ReminderError(str(error)) from error
+
+        reminder_data = {
+            "msg": msg,
+            "unique_id": time_length.unique_id,
+            "timeout": time_length.timeout,
+        }
+
+        handler = ReminderFileHandler(self._user)
+        reminder = handler.write(**reminder_data)
+
+        return f"```{reminder}```"
+
+    def show_reminders(self):
+        """ Show all reminders """
+        reminder_str = "```Your Reminders:\n"
+        for reminder in ReminderFileHandler(self._user).reminders:
+            reminder_str += f"\n{reminder}"
+
+        return f"{reminder_str}```"
+
+    def delete(self, reminder_id):
+        """ Delete a user's remind using the id """
+        reminder = ReminderFileHandler(self._user).load(reminder_id)
+        reminder.delete()
+
+        return f"```Ok. I've deleted:\n{reminder}```"

--- a/saltbot/timelength.py
+++ b/saltbot/timelength.py
@@ -1,0 +1,45 @@
+"""
+    TimeLength module for operations on units like "3 seconds"
+"""
+
+import time
+import uuid
+
+UNIT_DICT = {
+    "year": 31536000,
+    "month": 2592000,
+    "months": 2592000,
+    "weeks": 604800,
+    "week": 604800,
+    "days": 86400,
+    "day": 86400,
+    "hours": 3600,
+    "hour": 3600,
+    "minutes": 60,
+    "minute": 60,
+    "seconds": 1,
+    "second": 1,
+}
+
+
+class TimeLength:
+    """ TimeLength class """
+
+    def __init__(self, unit, amount_of_time):
+        try:
+            multiplier = UNIT_DICT[unit]
+        except KeyError as error:
+            raise ValueError from error
+
+        self._id = str(uuid.uuid4()).split("-")[0]
+        self._timeout = int(time.time()) + int(amount_of_time) * multiplier
+
+    @property
+    def timeout(self):
+        """ Epoch timeout """
+        return self._timeout
+
+    @property
+    def unique_id(self):
+        """ Unique ID """
+        return self._id

--- a/saltbot/timelength.py
+++ b/saltbot/timelength.py
@@ -29,7 +29,7 @@ class TimeLength:
         try:
             multiplier = UNIT_DICT[unit]
         except KeyError as error:
-            raise ValueError from error
+            raise ValueError(f"```Invalid unit {unit}```") from error
 
         self._id = str(uuid.uuid4()).split("-")[0]
         self._timeout = int(time.time()) + int(amount_of_time) * multiplier

--- a/saltbot/version.py
+++ b/saltbot/version.py
@@ -1,3 +1,3 @@
 """ Version file """
 
-VERSION = "2.4.6"
+VERSION = "2.5.0"


### PR DESCRIPTION
# What/Why
It would be really nice if `SaltBot` can keep up with reminders. This PR adds functionality to do just that.

## Setting reminders
Setting reminders must follow the format `!remind set <REMINDER-MSG> in <NUMBER> <UNIT>`.

For Example:
```
!remind set do something in 5 seconds
```

## Showing reminders
To show all reminders, use `!remind show` and the reminders will output in this way:
```
3567fca7: "eat pizza" at Feb 13, 2021 at 07:52:14 PM
ad90d4a6: "eat another pizza" at Feb 13, 2021 at 07:52:35 PM
d125250d: "eat other pizza" at Feb 13, 2021 at 07:51:21 PM
```

## Deleting reminders
You can delete reminders by their ID. If you wanted to delete the first reminder in the list above, use:
```
!remind delete 3567fca7
```

## Future enhancements to add:
 - Allow users to specify an end date instead of a timespan (something like ends Friday November 2nd at 5:00 PM)
 - Sort the list of reminders in order of ending soonest (consider allowing user to specify sorting)