### PR TITLE
Added fix to set localizations

### DIFF
--- a/saltbot/reminder.py
+++ b/saltbot/reminder.py
@@ -9,6 +9,8 @@ import os
 from pathlib import Path
 import time
 
+import pytz
+
 from timelength import TimeLength
 
 REMINDER_DIR = os.path.join(str(Path.home()), ".config/saltbot/reminders")
@@ -44,9 +46,12 @@ class ReminderFile(dict):
             self._read()
 
     def __str__(self):
-        formatted_time = datetime.fromtimestamp(self.timeout).strftime(
-            "%b %d, %Y at %I:%M:%S %p"
-        )
+        dt_obj = datetime.fromtimestamp(self.timeout)
+        timezone = pytz.timezone("US/Eastern")
+        timezone.localize(dt_obj)
+
+        formatted_time = dt_obj.strftime("%b %d, %Y at %I:%M:%S %p ET")
+
         return f'{self.unique_id}: "{self.msg}" at {formatted_time}'
 
     @property

--- a/saltbot/version.py
+++ b/saltbot/version.py
@@ -1,3 +1,3 @@
 """ Version file """
 
-VERSION = "2.5.0"
+VERSION = "2.5.1"


### PR DESCRIPTION
# What/Why
Not only do I need to set the locale on my pi, I need to also specify a timezone for the datetime object or else everything will work out of UTC. This PR hardcodes the timezone to Eastern US until I add functionality for user preferences.