### PR TITLE
Tests for API modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
+# Files created at runtime
 log.txt
 temp.jpg
+
+# Pycache
 **/__pycache__/**
-auth.env
+
+# Dev Environment directories
+.coverage
+.venv

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+black==20.8b1
+coverage==5.4
+pylint==2.6.0
+pytest==6.2.2
+requests==2.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 discord.py==1.3.4
+pytz==2021.1
 requests==2.24.0

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+PYTHONPATH=$(pwd)/saltbot coverage run --source=saltbot -m pytest tests
+if [ $? != 0 ]; then
+    echo "One or more tests failed!"
+    exit 1
+fi
+
+coverage report -m

--- a/saltbot/api.py
+++ b/saltbot/api.py
@@ -27,6 +27,7 @@ class API:
 
     def validate_status(self):
         """ Check if status code was 200 """
+        print(self.response.status_code)
         if self.response.status_code != HTTPStatus.OK:
             raise APIError("```Sorry, I had trouble getting that query :(```")
 

--- a/saltbot/api.py
+++ b/saltbot/api.py
@@ -23,20 +23,12 @@ class API:
 
     def _request(self):
         """ Do an HTTP GET on the url """
-        resp = requests.get(self.url)
-        if resp.status_code != HTTPStatus.OK:
-            return None
-
-        return resp
+        return requests.get(self.url)
 
     def validate_status(self):
-        """ Verify a 200 response code """
-        try:
-            self.response.raise_for_status()
-        except requests.HTTPError as error:
-            raise APIError(
-                "```Sorry, I had trouble getting that query :(```"
-            ) from error
+        """ Check if status code was 200 """
+        if self.response.status_code != HTTPStatus.OK:
+            raise APIError("```Sorry, I had trouble getting that query :(```")
 
     @staticmethod
     def validate_idx(idx, max_idx):

--- a/saltbot/poll.py
+++ b/saltbot/poll.py
@@ -74,7 +74,7 @@ class Poll:
             self.votes = data["votes"]
         except KeyError as error:
             raise ValueError(
-                "```Something went wrong with poll {poll_id}```"
+                f"```Something went wrong with poll {poll_id}```"
             ) from error
 
     def delete(self):
@@ -84,7 +84,7 @@ class Poll:
         try:
             os.remove(f"{POLL_DIR}/{self._poll_id}.json")
         except FileNotFoundError:
-            print("Warning: {self._poll_id} does not exist!")
+            print(f"Warning: {self._poll_id} does not exist!")
 
 
 async def monitor_polls(discord_client):

--- a/saltbot/youtube.py
+++ b/saltbot/youtube.py
@@ -2,8 +2,9 @@
 import os
 from api import API, APIError
 
-YOUTUBE_AUTH = os.environ["YOUTUBE_AUTH"]
+YOUTUBE_AUTH = os.getenv("YOUTUBE_AUTH")
 YOUTUBE_MAX_IDX = 49
+MAX_REQUESTED_VIDS = 50
 BASE_URL = "https://www.youtube.com/watch?v="
 
 
@@ -28,7 +29,7 @@ class Youtube(API):
         query = ",".join(query_args)
         return (
             f"https://www.googleapis.com/youtube/v3/search?key={YOUTUBE_AUTH}"
-            f"&q={query}&maxResults=50&type=video"
+            f"&q={query}&maxResults={MAX_REQUESTED_VIDS}&type=video"
         )
 
     @property

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,46 @@
+""" API Test Module """
+
+from unittest import mock
+
+import pytest
+
+from api import APIError, API
+
+
+def test_create_url():
+    """ Test creating the url is not implemented for the base class """
+    with pytest.raises(NotImplementedError):
+        API("foo")
+
+
+def test_request():
+    """ Test making a request on the url """
+    with mock.patch("api.API._create_url") as mock_create:
+        mock_create.return_value = "https://google.com"
+        with mock.patch("requests.get") as mock_get:
+            with mock.patch("api.API.validate_status"):
+                API("foo")
+                mock_get.assert_called()
+
+
+def test_validate_idx():
+    """ Test the validation of the response index """
+    with mock.patch("api.API._request"):
+        with mock.patch("api.API._create_url"):
+            with mock.patch("api.API.validate_status"):
+                api = API("foo")
+
+                # Test not an integer specified
+                with pytest.raises(APIError) as error:
+                    api.validate_idx("foo", "bar")
+                assert "You have to specify an integer" in str(error)
+
+                # Test index above valid range
+                with pytest.raises(APIError) as error:
+                    api.validate_idx(idx=5, max_idx=4)
+                assert "The index must be between 0 and" in str(error)
+
+                # Test index below valid range
+                with pytest.raises(APIError) as error:
+                    api.validate_idx(idx=-1, max_idx=4)
+                assert "The index must be between 0 and" in str(error)

--- a/tests/test_giphy.py
+++ b/tests/test_giphy.py
@@ -1,0 +1,74 @@
+""" Giphy Test Module """
+
+from unittest import mock
+
+import pytest
+from requests.models import Response
+
+from api import APIError
+from giphy import Giphy, GIPHY_AUTH
+
+
+@pytest.fixture(name="mock_response")
+def create_mock_response():
+    """ Create a mock requests response object """
+    resp = mock.Mock(spec=Response)
+    resp.status_code = 200
+    resp.json.return_value = {"data": [{"bitly_gif_url": "foo"}]}
+    return resp
+
+
+@mock.patch("api.API._request")
+def test_request_gif(mock_request, mock_response):
+    """ Test getting a gif """
+    # Try getting a good gif
+    mock_request.return_value = mock_response
+    giphy = Giphy("dog")
+    assert (
+        giphy.url == f"http://api.giphy.com/v1/gifs/search?q=dog&api_key={GIPHY_AUTH}"
+    )
+
+    # Try getting a gif but bad status code
+    for bad_code in (400, 404, 500):
+        mock_response.status_code = bad_code
+        with pytest.raises(APIError) as error:
+            giphy = Giphy("dog")
+
+        assert "Sorry, I had trouble getting that query" in str(error)
+
+
+@mock.patch("api.API._request")
+def test_giphy_properties(mock_request, mock_response):
+    """ Test the giphy {num_gifs} and {all_gifs} properties """
+    mock_request.return_value = mock_response
+
+    # Mock response has 1 "gif"
+    giphy = Giphy("dog")
+    assert giphy.num_gifs == 1
+    assert giphy.all_gifs == ["foo"]
+
+
+@mock.patch("api.API._request")
+def test_get_gif(mock_request, mock_response):
+    """ Test getting a gif and retrieving from the json resp """
+    mock_request.return_value = mock_response
+
+    giphy = Giphy("dog")
+    assert giphy.get_gif(0) == "foo"
+
+
+@mock.patch("api.API._request")
+def test_validate_num_gifs(mock_request, mock_response):
+    """ Test validation of the number of gifs in a resp """
+    # Test a non-zero number of gifs
+    mock_request.return_value = mock_response
+    giphy = Giphy("dog")
+    giphy.validate_num_gifs()
+
+    # Test a zero number of gifs
+    mock_response.json.return_value = {"data": []}
+    giphy = Giphy("dog")
+    with pytest.raises(APIError) as error:
+        giphy.validate_num_gifs()
+
+    assert "Sorry, there were no gifs" in str(error)

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -1,0 +1,44 @@
+""" Poll Test Module """
+
+import os
+
+import pytest
+
+from poll import Poll, POLL_DIR, POLL_HELP_MSG
+from timelength import TimeLength
+
+def test_poll_save_load(capsys):
+    """ Test saving and loading a poll """
+
+    # Test saving a poll
+    poll = Poll(time_length=TimeLength("hours", 5), votes=[], prompt="foo", channel_id=1234)
+
+    poll.save()
+    assert os.path.isfile(f"{POLL_DIR}/{poll.poll_id}.json")
+
+    # Test Loading a poll
+    other_poll = Poll()
+    other_poll.load(poll.poll_id)
+
+    assert poll.poll_id == other_poll.poll_id
+    assert poll.expiry == other_poll.expiry
+    assert poll.prompt == other_poll.prompt
+    assert poll.choices == other_poll.choices
+    assert poll.votes == other_poll.votes
+    assert poll.channel_id == other_poll.channel_id
+
+    # Test error loading poll
+    with open(f"{POLL_DIR}/1234.json", "w") as stream:
+        stream.write("{}")
+    with pytest.raises(ValueError) as error:
+        other_poll.load("1234")
+
+    assert f"Something went wrong with poll 1234" in str(error)
+
+    # Test delete
+    poll.delete()
+    other_poll.delete()
+    assert not os.path.isfile(poll.poll_id)
+
+    poll.delete()
+    assert f"Warning: {poll.poll_id} does not exist" in capsys.readouterr().out

--- a/tests/test_timelength.py
+++ b/tests/test_timelength.py
@@ -1,0 +1,29 @@
+""" TimeLength Test Module """
+
+import time
+
+import pytest
+
+from timelength import TimeLength, UNIT_DICT
+
+def test_timelength():
+    """ Test timelength functions work like they should """
+    # Test unit in dict
+    for unit in UNIT_DICT:
+        time_length = TimeLength(unit, 5)
+
+    # Test unit not in dict
+    with pytest.raises(ValueError) as error:
+        time_length = TimeLength("foo", 5)
+
+    # Test Timeout Calculation
+    time_length = TimeLength("hours", 5)
+    assert time_length.timeout <= UNIT_DICT["hours"] * 5 + time.time()
+
+    assert "Invalid unit foo" in str(error)
+
+def test_different_ids():
+    """ Test timelengths have different IDs  10 times """
+    time_length_id = TimeLength("second", 1).unique_id
+    for _ in range(10):
+        assert time_length_id != TimeLength("second", 1).unique_id

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -1,0 +1,40 @@
+""" Youtube Test Module """
+
+from unittest import mock
+
+from requests.models import Response
+import pytest
+
+from api import APIError
+from youtube import Youtube, YOUTUBE_AUTH, MAX_REQUESTED_VIDS, BASE_URL
+
+
+@pytest.fixture(name="mock_response")
+def create_mock_response():
+    """ Create a mock requests response object """
+    resp = mock.Mock(spec=Response)
+    resp.status_code = 200
+    resp.json.return_value = {"items": [{"id": {"videoId": "isaac"}}]}
+    return resp
+
+
+@mock.patch("api.API._request")
+def test_get_video(mock_request, mock_response):
+    """ Test getting a YT video """
+    mock_request.return_value = mock_response
+    youtube = Youtube("northernlion")
+    assert youtube.url == (
+        f"https://www.googleapis.com/youtube/v3/search"
+        f"?key={YOUTUBE_AUTH}&q=northernlion&maxResults"
+        f"={MAX_REQUESTED_VIDS}&type=video"
+    )
+
+    assert youtube.get_video(0) == f"{BASE_URL}isaac"
+
+    # Test getting a youtube video but no results
+    mock_response.json.return_value = {"items": []}
+    youtube = Youtube("northernlion")
+    with pytest.raises(APIError) as error:
+        youtube.validate_num_vids()
+
+    assert "Sorry, there were no videos" in str(error)


### PR DESCRIPTION
# What/Why

Saltbot has no tests :(

This PR is one of many to add tests as well as coverage. This PR not only adds tests for `giphy.py`, `youtube.py` and `api.py`, but it also adds a test runner bash script, coverage call, and an updated `.gitignore` for developer related folders like `.venv` and `.coverage`

## Testing
```
Name                    Stmts   Miss  Cover   Missing
-----------------------------------------------------
saltbot/__init__.py         0      0   100%
saltbot/__main__.py         5      5     0%   4-11
saltbot/api.py             24      0   100%
saltbot/commands.py       189    189     0%   3-374
saltbot/controller.py      39     39     0%   2-61
saltbot/giphy.py           20      0   100%
saltbot/logger.py          19     19     0%   4-32
saltbot/poll.py            72     24    67%   92-124
saltbot/reminder.py       125    125     0%   4-221
saltbot/timelength.py      15      0   100%
saltbot/version.py          1      1     0%   3
saltbot/youtube.py         20      0   100%
-----------------------------------------------------
TOTAL                     529    402    24%
```