### PR TITLE
Flush

### DIFF
--- a/saltbot/commands.py
+++ b/saltbot/commands.py
@@ -55,7 +55,6 @@ def _get_idx_from_args(args):
                 return_args.remove(idx)
 
         try:
-            print(idx)
             return int(idx), return_args
         except ValueError as error:
             raise ValueError(

--- a/saltbot/controller.py
+++ b/saltbot/controller.py
@@ -46,7 +46,7 @@ async def on_message(msg):
 
         except Exception as error:  #  pylint: disable=broad-except
             error_msg = f"Unexpected error with id: {uuid.uuid4()}"
-            print(f"{error_msg} {error}")
+            print(f"{error_msg} {error}", flush=True)
             traceback.print_exc()
             await msg.channel.send(f"```{error_msg} :(```")
 

--- a/saltbot/logger.py
+++ b/saltbot/logger.py
@@ -11,12 +11,12 @@ class Logger:
     def log(self, msg):
         """ Print the message and write to the log file """
         try:
-            print(msg)
+            print(msg, flush=True)
         except UnicodeDecodeError:
             print(
                 "WARN: Could not print message. User, channel or msg had unicode bytes"
             )
-            print("WARN: Check the logfile")
+            print("WARN: Check the logfile", flush=True)
         with open(self._logfile, "a") as stream:
             stream.write(f"{msg}\n")
 

--- a/saltbot/poll.py
+++ b/saltbot/poll.py
@@ -84,7 +84,7 @@ class Poll:
         try:
             os.remove(f"{POLL_DIR}/{self._poll_id}.json")
         except FileNotFoundError:
-            print(f"Warning: {self._poll_id} does not exist!")
+            print(f"Warning: {self._poll_id} does not exist!", flush=True)
 
 
 async def monitor_polls(discord_client):


### PR DESCRIPTION
# 2.5.2 Patch notes
 - Saltbot now no longer crashes when the username, message, or channel name as an emoji in it
 - In the event of an error, a code is given back to the user so that users can contact me with the error code and I can look up the exact error,
 - I flushed stdout with each `print` call to ensure that logs get printed in the kubernetes pods
 - I removed unnecessary logging