### PR TITLE
Fixed help message to not repeat the word 'commands'

### DIFF
--- a/saltbot/commands.py
+++ b/saltbot/commands.py
@@ -103,7 +103,7 @@ class Command:
         """
         ret_msg = (
             f"```Good salty day to you {self._user}! Here's a list of commands "
-            "commands that I understand:\n\n"
+            "that I understand:\n\n"
         )
 
         for msg in MSG_DICT:

--- a/saltbot/version.py
+++ b/saltbot/version.py
@@ -1,3 +1,3 @@
 """ Version file """
 
-VERSION = "2.5.2"
+VERSION = "2.5.3"


### PR DESCRIPTION
# Version 2.5.3
 - Help message no longer repeats the word `commands`