### PR TITLE
Alpine base with python3.9

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Build and Deliver
       if: success()
       run: |
-        docker buildx build --platform linux/arm/v7 -t highsaltlevels/saltbot:latest-arm64 --output type=image,push=true .
+        docker buildx build --platform linux/arm64 -t highsaltlevels/saltbot:latest-arm64 --output type=image,push=true .
 
     - name: Deploy Latest
       if: success()

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,24 @@
-FROM ubuntu:18.04
-
-COPY requirements.txt saltbot /saltbot/
-
-RUN cd /saltbot && \
-    apt-get update && \ 
-	apt-get install --no-install-recommends -y \
-        build-essential \
-        python3-pip \
-        python3.8-dev && \
-    python3.8 -m pip install setuptools==39.0.1 wheel==0.37.0 && \
-    python3.8 -m pip install -r requirements.txt
+FROM python:3.9.7-alpine3.14 as builder
 
 WORKDIR /saltbot
 
-CMD python3.8 /saltbot
+COPY requirements.txt saltbot /
+
+RUN apk add gcc musl-dev zlib-dev && \
+    python3 -m pip install -r /requirements.txt pyinstaller==4.5.1 && \
+    pyinstaller -F -p "/" -n saltbot /__main__.py
+
+
+FROM alpine:3.14.2 as deliverable
+
+# Set up working directories
+RUN mkdir -p /.config/saltbot/reminders && \
+    mkdir -p /.config/saltbot/polls && \
+    touch /log.txt && \
+    chown -R 69:420 /.config && \
+    chown -R 69:420 /log.txt
+
+COPY --chown=69:420 --from=builder /saltbot/dist/saltbot /saltbot
+USER 69:420
+
+ENTRYPOINT /saltbot

--- a/deploy.sh
+++ b/deploy.sh
@@ -30,11 +30,13 @@ function prepare_keys() {
 }
 
 function redeploy() {
+    UPDATE_COMMAND="cd ~/saltbot2.0 && git pull origin master"
     DEPLOY_COMMAND="kubectl -n saltbot rollout restart deployment saltbot"
     STATUS_CHECK="kubectl -n saltbot rollout status deployment saltbot"
     PROXY_COMMAND="ssh -q -o StrictHostKeyChecking=no -i ${BASTION_KEY_PATH} -p ${BASTION_PORT} -W %h:%p ${BASTION_USER}@${BASTION_HOST}"
 
     echo "Redeploying..."
+    ssh -q -v -o StrictHostKeyChecking=no -i ${K8S_KEY_PATH} -p ${K8S_PORT} -o ProxyCommand="${PROXY_COMMAND}" ${K8S_USER}@${K8S_HOST} "${UPDATE_COMMAND}"
     ssh -q -o StrictHostKeyChecking=no -i ${K8S_KEY_PATH} -p ${K8S_PORT} -o ProxyCommand="${PROXY_COMMAND}" ${K8S_USER}@${K8S_HOST} "${DEPLOY_COMMAND}"
     ssh -q -o StrictHostKeyChecking=no -i ${K8S_KEY_PATH} -p ${K8S_PORT} -o ProxyCommand="${PROXY_COMMAND}" ${K8S_USER}@${K8S_HOST} "${STATUS_CHECK}"
     echo "Redeploy Successful!"

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -26,3 +26,6 @@ spec:
           value: __GIPHY_AUTH__
         - name: YOUTUBE_AUTH
           value: __YOUTUBE_AUTH__
+      securityContext:
+        runAsUser: 69
+        runAsGroup: 420

--- a/saltbot/version.py
+++ b/saltbot/version.py
@@ -1,3 +1,3 @@
 """ Version file """
 
-VERSION = "2.5.4"
+VERSION = "2.5.5"


### PR DESCRIPTION
# Version 2.5.5

- Run saltbot on alpine instead of ubuntu for a lighter image
- Deliver a binary from a builder stage to further lighten the image
- Run the image as a different user and group to minimize hacking blast radius
- Build for 64 bit arm instead of 32 bit
- Run on python3.9 instead of python3.6