### PR TITLE
Python base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ temp.jpg
 # Dev Environment directories
 .coverage
 .venv
+
+# For the docker-compose.yml
+# Use this to set the auth env vars.
+# https://docs.docker.com/compose/compose-file/compose-file-v3/#env_file
+auth.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,19 @@
-FROM python:3.9.7-alpine3.14 as builder
+FROM python:3.9.7-alpine3.14
 
 WORKDIR /saltbot
 
-COPY requirements.txt saltbot /
+COPY requirements.txt saltbot/* /saltbot/
 
-RUN apk add gcc musl-dev zlib-dev && \
-    python3 -m pip install -r /requirements.txt pyinstaller==4.5.1 && \
-    pyinstaller -F -p "/" -n saltbot /__main__.py
-
-
-FROM alpine:3.14.2 as deliverable
-
-# Set up working directories
-RUN apk add tzdata && \
+RUN apk add tzdata gcc musl-dev zlib-dev && \
+    python3 -m pip install -r /saltbot/requirements.txt && \
     cp /usr/share/zoneinfo/US/Eastern /etc/localtime && \
     echo "US/Eastern" > /etc/timezone && \
     mkdir -p /.config/saltbot/reminders && \
     mkdir -p /.config/saltbot/polls && \
-    touch /log.txt && \
+    touch /saltbot/log.txt && \
     chown -R 69:420 /.config && \
-    chown -R 69:420 /log.txt
+    chown -R 69:420 /saltbot/log.txt
 
-COPY --chown=69:420 --from=builder /saltbot/dist/saltbot /saltbot
 USER 69:420
 
-ENTRYPOINT /saltbot
+ENTRYPOINT python3 /saltbot


### PR DESCRIPTION
#    What/Why
Saltbot keeps posting duplicate messages when posting poll results or reminders. I think this is due to the way that saltbot is being run.

Previously, I'd use pyinstaller to build a small bundled python app that I'd just copy over to a really slim alpine linux image.  unfortunately, I think bash, containerd, or some runtime process is duplicating each coroutine as a separate process in the container. Or at least `ps` would reveal multiple instances of saltbot running.

With this commit, we'll use a slightly larger base container (was 5.6MB, now 45.1MB), to run saltbot via the python interpreter directly, but still on alpine.

This commit also increases the size of the built container from 18.7MB to 199MB :(

## Anything Else
Yeah, There's an `auth.env` file that you can specify that gets used by the `docker-compose.yml` file for setting env vars. I figured it'd be best to add it to the `.gitignore` so that no one accidentally commits their `auth.env` 😅 