### PR TITLE
Reminder fix

### DIFF
--- a/messenger/controller.py
+++ b/messenger/controller.py
@@ -66,7 +66,9 @@ class Controller:
     @staticmethod
     def _delete_config_map(name):
         """Delete the poll config map"""
+        LOGGER.log(f"Deleting ConfigMap {name}")
         ConfigMap().delete(name)
+        LOGGER.log(f"Successfully deleted ConfigMap {name}")
 
 
 @CLIENT.event

--- a/messenger/messenger.py
+++ b/messenger/messenger.py
@@ -39,6 +39,9 @@ class Messenger:
 
     async def send(self, msg, spec):
         """Send the message to the channel or author"""
+        LOGGER.log(
+            f"Attempting to send reminder {spec['unique_id']} to {spec['channel']}"
+        )
         channel = self._client.get_channel(int(spec["channel"]))
         if channel is None:
             LOGGER.log("It's a DM, look up the channel")

--- a/saltbot/reminder.py
+++ b/saltbot/reminder.py
@@ -125,7 +125,7 @@ class Reminder:
     def _get_reminder_str(reminder):
         """Take the raw reminder response and convert it to human readable"""
         # ConfigMaps only store strings so we need to parse to int
-        dt_obj = datetime.fromtimestamp(int(reminder["timeout"]))
+        dt_obj = datetime.fromtimestamp(int(reminder["expiry"]))
         timezone = pytz.timezone("US/Eastern")
         timezone.localize(dt_obj)
 

--- a/saltbot/version.py
+++ b/saltbot/version.py
@@ -1,3 +1,3 @@
 """ Version file """
 
-VERSION = "2.5.6"
+VERSION = "2.5.7"


### PR DESCRIPTION
# What/Why
This PR fixes a `KeyError` when trying to handle a `!remind show` command. Also add a bit of logging to `messenger` so I know if it's chunking on something or if it even attempted to send the message. Also log when deleting configmaps so I know when `messenger` deleted the configmap as opposed to another source.