### PR TITLE
Fix waifu

### DIFF
--- a/saltbot/commands.py
+++ b/saltbot/commands.py
@@ -332,9 +332,9 @@ class Command:
 
             resp = requests.get(url, stream=True)
             if resp.status_code == 200:
-                with open("temp.jpg", "wb") as stream:
+                with open("/tmp/temp.jpg", "wb") as stream:
                     stream.write(resp.content)
-                return "file", "temp.jpg"
+                return "file", "/tmp/temp.jpg"
 
         return "text", "```Sorry, I coudn't get that waifu :(```"
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3,12 +3,8 @@
 from unittest import mock
 
 import discord
-import pytest
 
 from commands import Command, MSG_DICT
-from poll import Poll, POLL_HELP_MSG
-from timelength import TimeLength
-from reminder import REMINDER_HELP_MSG
 from .utils import create_user_msg, create_mock_response
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -139,7 +139,7 @@ def test_waifu(m_request):
         m_request.return_value = create_mock_response(200, kind="youtube")
         kind, msg = Command(user_msg).commands[cmd]()
         assert kind == "file"
-        assert msg == "temp.jpg"
+        assert msg == "/tmp/temp.jpg"
 
 
 def test_nut():

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from controller import on_message, on_ready
+from controller import on_message
 
 pytestmark = pytest.mark.asyncio
 

--- a/tests/test_timelength.py
+++ b/tests/test_timelength.py
@@ -1,10 +1,6 @@
 """ TimeLength Test Module """
 
-import time
-
-import pytest
-
-from timelength import TimeLength, UNIT_DICT
+from timelength import TimeLength
 
 
 def test_different_ids():


### PR DESCRIPTION
# What/Why
The waifu feature was broken. It was erroring out with:
```
PermissionError: [Errno 13] Permission denied: 'temp.jpg'
```
This is because I temporarily write the file to disk and have the discord client send that back to the requester. Well, when I run the container, I run it as a non-root user which has no permission to write to any directory in the container except for `/tmp`. So I just changed the path to `/tmp/temp.jpg` and that worked.

## Pylint fixes
Turns out I haven't run `pylint` on the tests in a hot minute. There were several unused imports. I just removed those 😅 