### PR TITLE
Better configmap handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Use this to set the auth env vars.
 auth.env
+
+# Ignore coverage report
+coverage.out

--- a/cache/configmapcache_test.go
+++ b/cache/configmapcache_test.go
@@ -1,0 +1,855 @@
+package cache
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/highsaltlevels/saltbot/testutil"
+)
+
+func TestAddConfigMap(t *testing.T) {
+	tests := []struct {
+		name             string
+		configMap        interface{}
+		cache            *ConfigMapCache
+		expectedPoll     *Poll
+		expectedReminder *Reminder
+	}{
+		{
+			name: "Test successfully adding poll",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "poll-foo",
+				},
+				Data: map[string]string{
+					"json": `{"author":"1234","channel":"1234","prompt":"prompt","choices":["choice1","choice2"],"expiry":1234,"id":"1234","votes":{"0":["chooser"],"1":[]}}`,
+				},
+			},
+			cache: &ConfigMapCache{
+				polls:     map[string]Poll{},
+				reminders: map[string]Reminder{},
+			},
+			expectedPoll: &Poll{
+				Author:  "1234",
+				Channel: "1234",
+				Prompt:  "prompt",
+				Choices: []string{"choice1", "choice2"},
+				Expiry:  1234,
+				Id:      "1234",
+				Votes: map[string][]interface{}{
+					"0": []interface{}{"chooser"},
+					"1": []interface{}{},
+				},
+			},
+		},
+		{
+			name: "Test failure adding poll invalid JSON",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "poll-foo",
+				},
+				Data: map[string]string{
+					"json": "i am not json :)",
+				},
+			},
+			cache: &ConfigMapCache{
+				polls:     map[string]Poll{},
+				reminders: map[string]Reminder{},
+			},
+		},
+		{
+			name: "Test failure adding poll json missing",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "poll-foo",
+				},
+				Data: map[string]string{},
+			},
+			cache: &ConfigMapCache{
+				polls:     map[string]Poll{},
+				reminders: map[string]Reminder{},
+			},
+		},
+		{
+			name: "Test successfully adding reminder",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "reminder-foo",
+				},
+				Data: map[string]string{
+					"json": `{"author":"1234","channel":"1234","expiry":1234,"msg":"bloop","id":"1234"}`,
+				},
+			},
+			cache: &ConfigMapCache{
+				polls:     map[string]Poll{},
+				reminders: map[string]Reminder{},
+			},
+			expectedReminder: &Reminder{
+				Author:  "1234",
+				Channel: "1234",
+				Expiry:  1234,
+				Message: "bloop",
+				Id:      "1234",
+			},
+		},
+		{
+			name: "Test failure adding reminder invalid JSON",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "reminder-foo",
+				},
+				Data: map[string]string{
+					"json": "i am not json :)",
+				},
+			},
+			cache: &ConfigMapCache{
+				polls:     map[string]Poll{},
+				reminders: map[string]Reminder{},
+			},
+		},
+		{
+			name: "Test failure adding reminder json missing",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "reminder-foo",
+				},
+				Data: map[string]string{},
+			},
+			cache: &ConfigMapCache{
+				polls:     map[string]Poll{},
+				reminders: map[string]Reminder{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set the cache before adding
+			Cache = tt.cache
+			Cache.addConfigMap(tt.configMap)
+			if tt.expectedPoll != nil {
+				if len(Cache.polls) != 1 {
+					t.Fatalf("should have 1 poll, but got no polls")
+				}
+				for _, poll := range Cache.polls {
+					validatePoll(t, tt.expectedPoll, &poll)
+				}
+			} else {
+				if len(Cache.polls) != 0 {
+					t.Fatalf("expected no polls but got: %d", len(Cache.polls))
+				}
+			}
+			if tt.expectedReminder != nil {
+				if len(Cache.reminders) != 1 {
+					t.Fatalf("should have 1 reminder, but got no reminders")
+				}
+				for _, reminder := range Cache.reminders {
+					validateReminder(t, tt.expectedReminder, &reminder)
+				}
+			} else {
+				if len(Cache.reminders) != 0 {
+					t.Fatalf("expected no reminders but got: %d", len(Cache.reminders))
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateConfigMap(t *testing.T) {
+	tests := []struct {
+		name             string
+		configMap        interface{}
+		cache            *ConfigMapCache
+		expectedPoll     *Poll
+		expectedReminder *Reminder
+	}{
+		{
+			name: "Test successfully updating poll",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "poll-foo",
+				},
+				Data: map[string]string{
+					"json": `{"author":"1234","channel":"1234","prompt":"prompt","choices":["choice1","choice2"],"expiry":1234,"id":"1234","votes":{"0":["chooser"],"1":[]}}`,
+				},
+			},
+			cache: &ConfigMapCache{
+				polls: map[string]Poll{
+					"1234": Poll{
+						Author:  "1234",
+						Channel: "1234",
+						Prompt:  "prompt",
+						Choices: []string{"choice1", "choice2"},
+						Expiry:  1234,
+						Id:      "1234",
+						Votes: map[string][]interface{}{
+							"0": []interface{}{},
+							"1": []interface{}{"chooser"},
+						},
+					},
+				},
+				reminders: map[string]Reminder{},
+			},
+			expectedPoll: &Poll{
+				Author:  "1234",
+				Channel: "1234",
+				Prompt:  "prompt",
+				Choices: []string{"choice1", "choice2"},
+				Expiry:  1234,
+				Id:      "1234",
+				Votes: map[string][]interface{}{
+					"0": []interface{}{"chooser"},
+					"1": []interface{}{},
+				},
+			},
+		},
+		{
+			name: "Test failure updating poll invalid JSON",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "poll-foo",
+				},
+				Data: map[string]string{
+					"json": "i am not json :)",
+				},
+			},
+			cache: &ConfigMapCache{
+				polls:     map[string]Poll{},
+				reminders: map[string]Reminder{},
+			},
+		},
+		{
+			name: "Test successfully updating reminder",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "reminder-foo",
+				},
+				Data: map[string]string{
+					"json": `{"author":"1234","channel":"1234","expiry":1234,"msg":"bloop","id":"1234"}`,
+				},
+			},
+			cache: &ConfigMapCache{
+				polls: map[string]Poll{},
+				reminders: map[string]Reminder{
+					"1234": Reminder{
+						Author:  "1234",
+						Channel: "1234",
+						Expiry:  1234,
+						Message: "something else",
+						Id:      "1234",
+					},
+				},
+			},
+			expectedReminder: &Reminder{
+				Author:  "1234",
+				Channel: "1234",
+				Expiry:  1234,
+				Message: "bloop",
+				Id:      "1234",
+			},
+		},
+		{
+			name: "Test failure updating reminder invalid JSON",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "reminder-foo",
+				},
+				Data: map[string]string{
+					"json": "i am not json :)",
+				},
+			},
+			cache: &ConfigMapCache{
+				polls:     map[string]Poll{},
+				reminders: map[string]Reminder{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set the cache before adding
+			Cache = tt.cache
+			// We ignore the old object, so let's just reuse tt.configMap
+			Cache.updateConfigMap(tt.configMap, tt.configMap)
+			if tt.expectedPoll != nil {
+				if len(Cache.polls) != 1 {
+					t.Fatalf("should have 1 poll, but got no polls")
+				}
+				for _, poll := range Cache.polls {
+					validatePoll(t, tt.expectedPoll, &poll)
+				}
+			} else {
+				if len(Cache.polls) != 0 {
+					t.Fatalf("expected no polls but got: %d", len(Cache.polls))
+				}
+			}
+			if tt.expectedReminder != nil {
+				if len(Cache.reminders) != 1 {
+					t.Fatalf("should have 1 reminder, but got no reminders")
+				}
+				for _, reminder := range Cache.reminders {
+					validateReminder(t, tt.expectedReminder, &reminder)
+				}
+			} else {
+				if len(Cache.reminders) != 0 {
+					t.Fatalf("expected no reminders but got: %d", len(Cache.reminders))
+				}
+			}
+		})
+	}
+}
+
+func TestDeleteConfigMap(t *testing.T) {
+	tests := []struct {
+		name      string
+		configMap interface{}
+		cache     *ConfigMapCache
+	}{
+		{
+			name: "Test successfully deleting poll",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "poll-foo",
+				},
+				Data: map[string]string{
+					"json": `{"author":"1234","channel":"1234","prompt":"prompt","choices":["choice1","choice2"],"expiry":1234,"id":"1234","votes":{"0":["chooser"],"1":[]}}`,
+				},
+			},
+			cache: &ConfigMapCache{
+				polls: map[string]Poll{
+					"1234": Poll{
+						Author:  "1234",
+						Channel: "1234",
+						Prompt:  "prompt",
+						Choices: []string{"choice1", "choice2"},
+						Expiry:  1234,
+						Id:      "1234",
+						Votes: map[string][]interface{}{
+							"0": []interface{}{"chooser"},
+							"1": []interface{}{},
+						},
+					},
+				},
+				reminders: map[string]Reminder{},
+			},
+		},
+		{
+			name: "Test failure deleting poll invalid name",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "poll",
+				},
+				Data: map[string]string{
+					"json": "",
+				},
+			},
+			cache: &ConfigMapCache{
+				polls:     map[string]Poll{},
+				reminders: map[string]Reminder{},
+			},
+		},
+		{
+			name: "Test successfully deleting reminder",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "reminder-foo",
+				},
+				Data: map[string]string{
+					"json": `{"author":"1234","channel":"1234","expiry":1234,"msg":"bloop","id":"1234"}`,
+				},
+			},
+			cache: &ConfigMapCache{
+				polls: map[string]Poll{},
+				reminders: map[string]Reminder{
+					"1234": Reminder{
+						Author:  "1234",
+						Channel: "1234",
+						Expiry:  1234,
+						Message: "something else",
+						Id:      "1234",
+					},
+				},
+			},
+		},
+		{
+			name: "Test failure deleting reminder invalid name",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "reminder",
+				},
+				Data: map[string]string{
+					"json": "",
+				},
+			},
+			cache: &ConfigMapCache{
+				polls:     map[string]Poll{},
+				reminders: map[string]Reminder{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set the cache before adding
+			Cache = tt.cache
+			// We ignore the old object, so let's just reuse tt.configMap
+			Cache.deleteConfigMap(tt.configMap)
+		})
+	}
+}
+
+func TestAddPoll(t *testing.T) {
+	tests := []struct {
+		name          string
+		client        kubernetes.Interface
+		poll          *Poll
+		expectedError error
+	}{
+		{
+			name:   "Test adding poll successfully",
+			client: &testutil.MockK8sClient{},
+			poll: &Poll{
+				Id:     "1234",
+				Author: "1234",
+			},
+			expectedError: nil,
+		},
+		{
+			name:   "Test failed adding poll to k8s",
+			client: &testutil.MockErrorK8sClient{},
+			poll: &Poll{
+				Id:     "1234",
+				Author: "1234",
+			},
+			expectedError: errors.New(testutil.ExpectedError),
+		},
+		{
+			name:   "Test failed adding invalid poll",
+			client: &testutil.MockErrorK8sClient{},
+			poll: &Poll{
+				Id:     "1234",
+				Author: "1234",
+				Votes: map[string][]interface{}{
+					"1234": []interface{}{
+						make(chan bool),
+					},
+				},
+			},
+			expectedError: errors.New("failed to marshal poll"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Client = tt.client
+			c := ConfigMapCache{}
+
+			err := c.AddPoll(tt.poll)
+			if tt.expectedError == nil {
+				if err != nil {
+					t.Errorf("expected nil error, but got: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("got nil error but expected: %v", err)
+				}
+				if !strings.Contains(err.Error(), tt.expectedError.Error()) {
+					t.Errorf("expected: \"%v\" but got: \"%v\"", tt.expectedError, err)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdatePoll(t *testing.T) {
+	tests := []struct {
+		name          string
+		client        kubernetes.Interface
+		poll          *Poll
+		expectedError error
+	}{
+		{
+			name:   "Test updating poll successfully",
+			client: &testutil.MockK8sClient{},
+			poll: &Poll{
+				Id:     "1234",
+				Author: "1234",
+			},
+			expectedError: nil,
+		},
+		{
+			name:   "Test failed updating poll in k8s",
+			client: &testutil.MockErrorK8sClient{},
+			poll: &Poll{
+				Id:     "1234",
+				Author: "1234",
+			},
+			expectedError: errors.New(testutil.ExpectedError),
+		},
+		{
+			name:   "Test failed updating invalid poll",
+			client: &testutil.MockErrorK8sClient{},
+			poll: &Poll{
+				Id:     "1234",
+				Author: "1234",
+				Votes: map[string][]interface{}{
+					"1234": []interface{}{
+						make(chan bool),
+					},
+				},
+			},
+			expectedError: errors.New("failed to marshal poll"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Client = tt.client
+			c := ConfigMapCache{}
+
+			err := c.UpdatePoll(tt.poll)
+			if tt.expectedError == nil {
+				if err != nil {
+					t.Errorf("expected nil error, but got: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("got nil error but expected: %v", err)
+				}
+				if !strings.Contains(err.Error(), tt.expectedError.Error()) {
+					t.Errorf("expected: \"%v\" but got: \"%v\"", tt.expectedError, err)
+				}
+			}
+		})
+	}
+}
+
+func TestAddReminder(t *testing.T) {
+	tests := []struct {
+		name          string
+		client        kubernetes.Interface
+		reminder      *Reminder
+		expectedError error
+	}{
+		{
+			name:          "Test adding reminder successfully",
+			client:        &testutil.MockK8sClient{},
+			reminder:      &Reminder{},
+			expectedError: nil,
+		},
+		{
+			name:          "Test failed adding reminder to k8s",
+			client:        &testutil.MockErrorK8sClient{},
+			reminder:      &Reminder{},
+			expectedError: errors.New(testutil.ExpectedError),
+		},
+		{
+			name:   "Test failed adding invalid reminder",
+			client: &testutil.MockErrorK8sClient{},
+			reminder: &Reminder{
+				Message: make(chan bool),
+			},
+			expectedError: errors.New("failed to convert reminder to configMap"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Client = tt.client
+			c := ConfigMapCache{}
+
+			err := c.AddReminder(tt.reminder, "user")
+			if tt.expectedError == nil {
+				if err != nil {
+					t.Errorf("expected nil error, but got: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("got nil error but expected: %v", err)
+				}
+				if !strings.Contains(err.Error(), tt.expectedError.Error()) {
+					t.Errorf("expected: \"%v\" but got: \"%v\"", tt.expectedError, err)
+				}
+			}
+		})
+	}
+}
+
+func TestListPolls(t *testing.T) {
+	expected := map[string]Poll{
+		"1234": Poll{
+			Id: "1234",
+		},
+		"5678": Poll{
+			Id: "5678",
+		},
+	}
+	c := NewInMemConfigMapCache(expected, map[string]Reminder{})
+	actual := c.ListPolls()
+	for _, id := range []string{"1234", "5678"} {
+		if actual[id].Id != expected[id].Id {
+			t.Errorf("expected Id %s but got %s", expected[id].Id, actual[id].Id)
+		}
+	}
+}
+
+func TestGetPoll(t *testing.T) {
+	tests := []struct {
+		name         string
+		cache        *ConfigMapCache
+		id           string
+		author       string
+		expectedPoll *Poll
+	}{
+		{
+			name: "test successfully getting poll",
+			cache: NewInMemConfigMapCache(
+				map[string]Poll{
+					"1234": Poll{
+						Id:     "1234",
+						Author: "5678",
+					},
+				},
+				map[string]Reminder{},
+			),
+			expectedPoll: &Poll{
+				Id: "1234",
+			},
+			id:     "1234",
+			author: "5678",
+		},
+		{
+			name: "test failing to get poll",
+			cache: NewInMemConfigMapCache(
+				map[string]Poll{},
+				map[string]Reminder{},
+			),
+			expectedPoll: nil,
+			id:           "1234",
+			author:       "5678",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.cache.GetPoll(tt.id, tt.author)
+			if tt.expectedPoll == nil {
+				if actual != nil {
+					t.Errorf("expected nil poll but got: %v", actual)
+				}
+			} else {
+				if actual == nil {
+					t.Fatalf("expected poll: %v, but got nil poll", tt.expectedPoll)
+				}
+				if tt.expectedPoll.Id != actual.Id {
+					t.Errorf("expected id: %s, but got: %s", tt.expectedPoll.Id, actual.Id)
+				}
+			}
+		})
+	}
+}
+
+func TestListReminders(t *testing.T) {
+	expected := map[string]Reminder{
+		"1234": Reminder{
+			Id: "1234",
+		},
+		"5678": Reminder{
+			Id: "5678",
+		},
+	}
+	c := NewInMemConfigMapCache(map[string]Poll{}, expected)
+	actual := c.ListReminders()
+	for _, id := range []string{"1234", "5678"} {
+		if actual[id].Id != expected[id].Id {
+			t.Errorf("expected Id %s but got %s", expected[id].Id, actual[id].Id)
+		}
+	}
+}
+
+func TestGetReminder(t *testing.T) {
+	tests := []struct {
+		name             string
+		cache            *ConfigMapCache
+		id               string
+		author           string
+		expectedReminder *Reminder
+	}{
+		{
+			name: "test successfully getting reminder",
+			cache: NewInMemConfigMapCache(
+				map[string]Poll{},
+				map[string]Reminder{
+					"1234": Reminder{
+						Id:     "1234",
+						Author: "5678",
+					},
+				},
+			),
+			expectedReminder: &Reminder{
+				Id: "1234",
+			},
+			id:     "1234",
+			author: "5678",
+		},
+		{
+			name: "test failing to get reminder",
+			cache: NewInMemConfigMapCache(
+				map[string]Poll{},
+				map[string]Reminder{},
+			),
+			expectedReminder: nil,
+			id:               "1234",
+			author:           "5678",
+		},
+		{
+			name: "test failing to get reminder with different author",
+			cache: NewInMemConfigMapCache(
+				map[string]Poll{},
+				map[string]Reminder{
+					"1234": Reminder{
+						Id:     "1234",
+						Author: "5678",
+					},
+				},
+			),
+			expectedReminder: nil,
+			id:               "1234",
+			author:           "not the right one",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.cache.GetReminder(tt.id, tt.author)
+			if tt.expectedReminder == nil {
+				if actual != nil {
+					t.Errorf("expected nil poll but got: %v", actual)
+				}
+			} else {
+				if actual == nil {
+					t.Fatalf("expected poll: %v, but got nil poll", tt.expectedReminder)
+				}
+				if tt.expectedReminder.Id != actual.Id {
+					t.Errorf("expected id: %s, but got: %s", tt.expectedReminder.Id, actual.Id)
+				}
+			}
+		})
+	}
+}
+
+func TestDelete(t *testing.T) {
+	tests := []struct {
+		name   string
+		client kubernetes.Interface
+		cache  *ConfigMapCache
+	}{
+		{
+			name:   "Test delete poll from cache successfully",
+			client: &testutil.MockK8sClient{},
+			cache: NewInMemConfigMapCache(
+				map[string]Poll{
+					"1234": Poll{
+						Id:     "1234",
+						Author: "5678",
+					},
+				},
+				map[string]Reminder{},
+			),
+		},
+		{
+			name:   "Test failed to delete poll from cache",
+			client: &testutil.MockErrorK8sClient{},
+			cache: NewInMemConfigMapCache(
+				map[string]Poll{
+					"1234": Poll{
+						Id:     "1234",
+						Author: "5678",
+					},
+				},
+				map[string]Reminder{},
+			),
+		},
+		{
+			name:   "Test delete reminder from cache successfully",
+			client: &testutil.MockK8sClient{},
+			cache: NewInMemConfigMapCache(
+				map[string]Poll{},
+				map[string]Reminder{
+					"1234": Reminder{
+						Id:     "1234",
+						Author: "5678",
+					},
+				},
+			),
+		},
+		{
+			name:   "Test failed to delete reminder from cache",
+			client: &testutil.MockErrorK8sClient{},
+			cache: NewInMemConfigMapCache(
+				map[string]Poll{},
+				map[string]Reminder{
+					"1234": Reminder{
+						Id:     "1234",
+						Author: "5678",
+					},
+				},
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Client = tt.client
+			Cache = tt.cache
+
+			Cache.Delete("1234")
+		})
+	}
+}
+
+func validatePoll(t *testing.T, expected, actual *Poll) {
+	if actual.Author != expected.Author {
+		t.Errorf("incorrect author. Expected: %s, got: %s", expected.Author, actual.Author)
+	}
+	if actual.Channel != expected.Channel {
+		t.Errorf("incorrect channel. Expected: %s, got: %s", expected.Channel, actual.Channel)
+	}
+	if actual.Prompt != expected.Prompt {
+		t.Errorf("incorrect prompt. Expected: %s, got: %s", expected.Prompt, actual.Prompt)
+	}
+	if !reflect.DeepEqual(actual.Choices, expected.Choices) {
+		t.Errorf("incorrect choices. Expected: %v, got %v", expected.Choices, actual.Choices)
+	}
+	if actual.Expiry != expected.Expiry {
+		t.Errorf("incorrect expiry. Expected: %d, got: %d", expected.Expiry, actual.Expiry)
+	}
+	if actual.Id != expected.Id {
+		t.Errorf("incorrect id. Expected: %s, got: %s", expected.Id, actual.Id)
+	}
+	if !reflect.DeepEqual(actual.Votes, expected.Votes) {
+		t.Errorf("incorrect votes. Expected: %v, got %v", expected.Votes, actual.Votes)
+	}
+}
+
+func validateReminder(t *testing.T, expected, actual *Reminder) {
+	if actual.Author != expected.Author {
+		t.Errorf("incorrect author. Expected: %s, got: %s", expected.Author, actual.Author)
+	}
+	if actual.Channel != expected.Channel {
+		t.Errorf("incorrect channel. Expected: %s, got: %s", expected.Channel, actual.Channel)
+	}
+	if actual.Expiry != expected.Expiry {
+		t.Errorf("incorrect expiry. Expected: %d, got: %d", expected.Expiry, actual.Expiry)
+	}
+	if actual.Message != expected.Message {
+		t.Errorf("incorrect message. Expected: %s, got: %s", expected.Message, actual.Message)
+	}
+	if actual.Id != expected.Id {
+		t.Errorf("incorrect id. Expected: %s, got: %s", expected.Id, actual.Id)
+	}
+}

--- a/cache/poll.go
+++ b/cache/poll.go
@@ -9,13 +9,13 @@ import (
 )
 
 type Poll struct {
-	Author  string              `json:"author"`
-	Channel string              `json:"channel"`
-	Prompt  string              `json:"prompt"`
-	Choices []string            `json:"choices"`
-	Expiry  int64               `json:"expiry"`
-	Id      string              `json:"id"`
-	Votes   map[string][]string `json:"votes"`
+	Author  string                   `json:"author"`
+	Channel string                   `json:"channel"`
+	Prompt  string                   `json:"prompt"`
+	Choices []string                 `json:"choices"`
+	Expiry  int64                    `json:"expiry"`
+	Id      string                   `json:"id"`
+	Votes   map[string][]interface{} `json:"votes"`
 }
 
 func (p *Poll) FromConfigMap(configMap *corev1.ConfigMap) error {

--- a/cache/poll.go
+++ b/cache/poll.go
@@ -1,0 +1,52 @@
+package cache
+
+import (
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type Poll struct {
+	Author  string              `json:"author"`
+	Channel string              `json:"channel"`
+	Prompt  string              `json:"prompt"`
+	Choices []string            `json:"choices"`
+	Expiry  int64               `json:"expiry"`
+	Id      string              `json:"id"`
+	Votes   map[string][]string `json:"votes"`
+}
+
+func (p *Poll) FromConfigMap(configMap *corev1.ConfigMap) error {
+	jsonData, ok := configMap.Data["json"]
+	if !ok {
+		return fmt.Errorf("could not find json data in poll configmap")
+	}
+
+	err := json.Unmarshal([]byte(jsonData), &p)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal configmap to poll: %v", err)
+	}
+
+	return nil
+}
+
+func (p *Poll) ToConfigMap() (*corev1.ConfigMap, error) {
+	bytes, err := json.Marshal(p)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal poll: %v", err)
+	}
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "poll-" + p.Id,
+			Labels: map[string]string{
+				"author": p.Author,
+			},
+		},
+		Data: map[string]string{
+			"json": string(bytes),
+		},
+	}, nil
+}

--- a/cache/reminder.go
+++ b/cache/reminder.go
@@ -1,0 +1,50 @@
+package cache
+
+import (
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type Reminder struct {
+	Author  string `json:"author"`
+	Channel string `json:"channel"`
+	Expiry  int64  `json:"expiry"`
+	Message string `json:"msg"`
+	Id      string `json:"id"`
+}
+
+func (r *Reminder) FromConfigMap(configMap *corev1.ConfigMap) error {
+	jsonData, ok := configMap.Data["json"]
+	if !ok {
+		return fmt.Errorf("could not find json data in reminder configmap")
+	}
+
+	err := json.Unmarshal([]byte(jsonData), &r)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal configmap to reminder: %v", err)
+	}
+
+	return nil
+}
+
+func (r *Reminder) ToConfigMap() (*corev1.ConfigMap, error) {
+	bytes, err := json.Marshal(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal reminder: %v", err)
+	}
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "reminder-" + r.Id,
+			Labels: map[string]string{
+				"author": r.Author,
+			},
+		},
+		Data: map[string]string{
+			"json": string(bytes),
+		},
+	}, nil
+}

--- a/cache/reminder.go
+++ b/cache/reminder.go
@@ -9,11 +9,11 @@ import (
 )
 
 type Reminder struct {
-	Author  string `json:"author"`
-	Channel string `json:"channel"`
-	Expiry  int64  `json:"expiry"`
-	Message string `json:"msg"`
-	Id      string `json:"id"`
+	Author  string      `json:"author"`
+	Channel string      `json:"channel"`
+	Expiry  int64       `json:"expiry"`
+	Message interface{} `json:"msg"`
+	Id      string      `json:"id"`
 }
 
 func (r *Reminder) FromConfigMap(configMap *corev1.ConfigMap) error {

--- a/expirychecker/expirychecker_test.go
+++ b/expirychecker/expirychecker_test.go
@@ -1,0 +1,171 @@
+package expirychecker
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/highsaltlevels/saltbot/cache"
+	"github.com/highsaltlevels/saltbot/testutil"
+)
+
+type MockDiscordSession struct {
+	// error to return. Leave this as nil to return nil as error
+	err error
+
+	// used to save what would have been sent as a message
+	SentMessage string
+}
+
+func (m *MockDiscordSession) ChannelMessageSend(channelID string, content string, options ...discordgo.RequestOption) (*discordgo.Message, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	m.SentMessage = content
+	return nil, m.err
+}
+
+func TestPollerLoop(t *testing.T) {
+	tests := []struct {
+		name                 string
+		session              MockDiscordSession
+		client               kubernetes.Interface
+		cache                *cache.ConfigMapCache
+		expectedMessageParts []string
+	}{
+		{
+			name:    "Test send poll successfully",
+			session: MockDiscordSession{},
+			client:  &testutil.MockK8sClient{},
+			cache: cache.NewInMemConfigMapCache(
+				map[string]cache.Poll{
+					"1234": cache.Poll{
+						Prompt: "prompt",
+						Votes: map[string][]interface{}{
+							"0": []interface{}{"person1", "persion2"},
+							"1": []interface{}{"person3"},
+						},
+						Choices: []string{
+							"choice1",
+							"choice2",
+						},
+						Expiry: 0,
+					},
+				},
+				map[string]cache.Reminder{},
+			),
+			expectedMessageParts: []string{
+				"prompt",
+				"choice1",
+				"choice2",
+				"67%",
+				"33%",
+			},
+		},
+		{
+			name:    "Test send poll successfully but no one voted",
+			session: MockDiscordSession{},
+			client:  &testutil.MockK8sClient{},
+			cache: cache.NewInMemConfigMapCache(
+				map[string]cache.Poll{
+					"1234": cache.Poll{
+						Prompt: "prompt",
+						Votes: map[string][]interface{}{
+							"0": []interface{}{},
+							"1": []interface{}{},
+						},
+						Choices: []string{
+							"choice1",
+							"choice2",
+						},
+						Expiry: 0,
+					},
+				},
+				map[string]cache.Reminder{},
+			),
+			expectedMessageParts: []string{"No one voted on this poll"},
+		},
+		{
+			name:    "Test send reminder successfully",
+			session: MockDiscordSession{},
+			client:  &testutil.MockK8sClient{},
+			cache: cache.NewInMemConfigMapCache(
+				map[string]cache.Poll{},
+				map[string]cache.Reminder{
+					"1234": cache.Reminder{
+						Message: "message",
+						Expiry:  0,
+					},
+				},
+			),
+			expectedMessageParts: []string{"message"},
+		},
+		{
+			name:    "Test send poll discord session error",
+			session: MockDiscordSession{err: errors.New("foo")},
+			client:  &testutil.MockK8sClient{},
+			cache: cache.NewInMemConfigMapCache(
+				map[string]cache.Poll{
+					"1234": cache.Poll{
+						Prompt: "prompt",
+						Votes: map[string][]interface{}{
+							"0": []interface{}{},
+							"1": []interface{}{},
+						},
+						Choices: []string{
+							"choice1",
+							"choice2",
+						},
+						Expiry: 0,
+					},
+				},
+				map[string]cache.Reminder{},
+			),
+			expectedMessageParts: []string{},
+		},
+		{
+			name:    "Test send reminder discord session error",
+			session: MockDiscordSession{err: errors.New("foo")},
+			client:  &testutil.MockK8sClient{},
+			cache: cache.NewInMemConfigMapCache(
+				map[string]cache.Poll{},
+				map[string]cache.Reminder{
+					"1234": cache.Reminder{
+						Message: "message",
+						Expiry:  0,
+					},
+				},
+			),
+			expectedMessageParts: []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache.Cache = tt.cache
+			cache.Client = tt.client
+			ctx, cancel := context.WithCancel(context.Background())
+
+			poller := NewPoller(&tt.session, ctx)
+			go poller.Loop()
+			// Give 1.1 seconds to make sure the poll/reminder gets picked up.
+			time.Sleep(1100 * time.Millisecond)
+			cancel()
+
+			if len(tt.expectedMessageParts) == 0 && tt.session.SentMessage != "" {
+				t.Fatalf("expected no message to be sent, but got: %s", tt.session.SentMessage)
+			}
+
+			for _, msg := range tt.expectedMessageParts {
+				if !strings.Contains(tt.session.SentMessage, msg) {
+					t.Errorf("expected \"%s\" to be in \"%s\"", msg, tt.session.SentMessage)
+				}
+			}
+		})
+	}
+}

--- a/giphy/giphy.go
+++ b/giphy/giphy.go
@@ -16,6 +16,7 @@ import (
 )
 
 var token string
+var client util.HttpClientInterface
 
 type GiphyData struct {
 	// We only care about the bitly_gif_url
@@ -29,13 +30,18 @@ type GiphyResponse struct {
 func init() {
 	var ok bool
 	if token, ok = os.LookupEnv("GIPHY_AUTH"); !ok {
-		log.Fatal("failed to get giphy auth from env var")
+		log.Println("failed to get giphy auth from env var")
+		log.Println("continuing saltbot startup with partial functionality")
+	}
+
+	if client == nil {
+		client = &http.Client{}
 	}
 }
 
 func fetchGif(query string) (*GiphyResponse, error) {
 	url := fmt.Sprintf("http://api.giphy.com/v1/gifs/search?q=%s&api_key=%s", query, token)
-	resp, err := http.Get(url)
+	resp, err := client.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get giphy gif: %w", err)
 	}
@@ -47,7 +53,7 @@ func fetchGif(query string) (*GiphyResponse, error) {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read giphy resp: %w", err)
+		return nil, fmt.Errorf("failed to read giphy response: %w", err)
 	}
 
 	var gif GiphyResponse

--- a/giphy/giphy_test.go
+++ b/giphy/giphy_test.go
@@ -1,0 +1,254 @@
+package giphy
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/highsaltlevels/saltbot/util"
+)
+
+const expectedError = "expect me"
+
+type MockFailedReadCloser struct {
+	io.Reader
+	io.Closer
+}
+
+func (rc MockFailedReadCloser) Read(p []byte) (n int, err error) {
+	return 0, errors.New(expectedError)
+}
+
+func (rc MockFailedReadCloser) Close() error {
+	return errors.New(expectedError)
+}
+
+type MockHttpClient struct {
+	util.HttpClientInterface
+
+	// The response to return if successful
+	giphyResponse interface{}
+
+	// Used to determine if the mock client should return error or not
+	expectError bool
+
+	// Used to determine if mock client should return object that can't be read
+	expectIOError bool
+
+	// The response code to be used in the http response object
+	responseCode int
+}
+
+func (c *MockHttpClient) Get(url string) (*http.Response, error) {
+	if c.expectError {
+		return nil, errors.New(expectedError)
+	}
+
+	if c.expectIOError {
+		return &http.Response{
+			StatusCode: c.responseCode,
+			Body:       MockFailedReadCloser{},
+		}, nil
+	}
+
+	data, _ := json.Marshal(c.giphyResponse)
+
+	return &http.Response{
+		StatusCode: c.responseCode,
+		Body:       io.NopCloser(strings.NewReader(string(data))),
+	}, nil
+}
+
+func TestGet(t *testing.T) {
+	tests := []struct {
+		name            string
+		commandStr      string
+		giphyResponse   interface{}
+		getResponseCode int
+		// Should the client return an error instead. Omitting == false
+		shouldClientError bool
+		// Should the ReadCloser response body error. Omitting == false
+		shouldReadCloserError bool
+		expectedResponse      string
+		expectedError         error
+	}{
+		{
+			name:       "Test successful giphy fetch",
+			commandStr: "!giphy query",
+			giphyResponse: GiphyResponse{
+				Data: []GiphyData{
+					GiphyData{
+						Url: "foo",
+					},
+				},
+			},
+			getResponseCode:  http.StatusOK,
+			expectedResponse: "foo",
+			expectedError:    nil,
+		},
+		{
+			name:       "Test successful giphy fetch with short form",
+			commandStr: "!g query",
+			giphyResponse: GiphyResponse{
+				Data: []GiphyData{
+					GiphyData{
+						Url: "foo",
+					},
+				},
+			},
+			getResponseCode:  http.StatusOK,
+			expectedResponse: "foo",
+			expectedError:    nil,
+		},
+		{
+			name:       "Test successful giphy fetch with specific index",
+			commandStr: "!giphy query -i 0",
+			giphyResponse: GiphyResponse{
+				Data: []GiphyData{
+					GiphyData{
+						Url: "foo",
+					},
+				},
+			},
+			getResponseCode:  http.StatusOK,
+			expectedResponse: "foo",
+			expectedError:    nil,
+		},
+		{
+			name:       "Test successful giphy fetch all gifs",
+			commandStr: "!giphy query -a",
+			giphyResponse: GiphyResponse{
+				Data: []GiphyData{
+					GiphyData{
+						Url: "foo",
+					},
+					GiphyData{
+						Url: "bar",
+					},
+				},
+			},
+			getResponseCode:  http.StatusOK,
+			expectedResponse: "Here's all the gifs for that query:\nfoo\nbar\n",
+			expectedError:    nil,
+		},
+		{
+			name:       "Test successful giphy fetch all gifs with different placement of flag",
+			commandStr: "!giphy -a query",
+			giphyResponse: GiphyResponse{
+				Data: []GiphyData{
+					GiphyData{
+						Url: "foo",
+					},
+					GiphyData{
+						Url: "bar",
+					},
+				},
+			},
+			getResponseCode:  http.StatusOK,
+			expectedResponse: "Here's all the gifs for that query:\nfoo\nbar\n",
+			expectedError:    nil,
+		},
+		{
+			name:              "Test failed giphy fetch",
+			commandStr:        "!giphy query",
+			giphyResponse:     GiphyResponse{},
+			getResponseCode:   http.StatusOK,
+			shouldClientError: true,
+			expectedError:     errors.New(expectedError),
+		},
+		{
+			name:              "Test failed giphy all gifs fetch",
+			commandStr:        "!giphy query -a",
+			giphyResponse:     GiphyResponse{},
+			getResponseCode:   http.StatusOK,
+			shouldClientError: true,
+			expectedError:     errors.New(expectedError),
+		},
+		{
+			name:            "Test giphy fetch non-200 status code",
+			commandStr:      "!giphy query",
+			giphyResponse:   GiphyResponse{},
+			getResponseCode: http.StatusInternalServerError,
+			expectedError:   fmt.Errorf("received status code %d from giphy", http.StatusInternalServerError),
+		},
+		{
+			name:             "Test missing command string",
+			commandStr:       "!giphy",
+			giphyResponse:    GiphyResponse{},
+			getResponseCode:  http.StatusOK,
+			expectedResponse: "```Must specify giphy query like: \"!giphy dog\"```",
+			expectedError:    nil,
+		},
+		{
+			name:             "Test invalid command string",
+			commandStr:       "!giphy -i foo",
+			giphyResponse:    GiphyResponse{},
+			getResponseCode:  http.StatusOK,
+			expectedResponse: "```Must use a valid number between 0 and 24```",
+			expectedError:    nil,
+		},
+		{
+			name:             "Test index is negative",
+			commandStr:       "!giphy -i -1",
+			giphyResponse:    GiphyResponse{},
+			getResponseCode:  http.StatusOK,
+			expectedResponse: "```Must use a valid number between 0 and 24```",
+			expectedError:    nil,
+		},
+		{
+			name:             "Test index is too large",
+			commandStr:       "!giphy -i 25",
+			giphyResponse:    GiphyResponse{},
+			getResponseCode:  http.StatusOK,
+			expectedResponse: "```Must use a valid number between 0 and 24```",
+			expectedError:    nil,
+		},
+		{
+			name:            "Test unmarshalable giphy response",
+			commandStr:      "!giphy query",
+			giphyResponse:   []byte("this can't be marshaled"),
+			getResponseCode: http.StatusOK,
+			expectedError:   errors.New("failed to unmarshal giphy response"),
+		},
+		{
+			name:                  "Test giphy unreadable response",
+			commandStr:            "!giphy query",
+			giphyResponse:         GiphyResponse{},
+			getResponseCode:       http.StatusOK,
+			shouldReadCloserError: true,
+			expectedError:         errors.New("failed to read giphy response"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client = &MockHttpClient{
+				expectError:   tt.shouldClientError,
+				expectIOError: tt.shouldReadCloserError,
+				responseCode:  tt.getResponseCode,
+				giphyResponse: tt.giphyResponse,
+			}
+
+			msg, err := Get(tt.commandStr)
+			if tt.expectedError != nil {
+				if err == nil {
+					t.Errorf("expected error '%v' to be returned but was nil", tt.expectedError)
+				}
+				if !strings.Contains(err.Error(), tt.expectedError.Error()) {
+					t.Errorf("expected error '%v', but got error '%v'", tt.expectedError, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error but got error: '%v'", err)
+				}
+				if msg.Content != tt.expectedResponse {
+					t.Errorf("expected message: '%s', but got '%s'", tt.expectedResponse, msg.Content)
+				}
+			}
+		})
+	}
+}

--- a/jeopardy/jeopardy.go
+++ b/jeopardy/jeopardy.go
@@ -8,7 +8,11 @@ import (
 	"net/http"
 
 	"github.com/bwmarrin/discordgo"
+
+	"github.com/highsaltlevels/saltbot/util"
 )
+
+var client util.HttpClientInterface
 
 type Clue struct {
 	Question string `json:"question"`
@@ -20,11 +24,17 @@ type JeopardyResponse struct {
 	Clues []Clue `json:"clues"`
 }
 
+func init() {
+	if client == nil {
+		client = &http.Client{}
+	}
+}
+
 func Get() (*discordgo.MessageSend, error) {
 	num := rand.Intn(18417)
 	url := fmt.Sprintf("http://jservice.io/api/category?id=%d", num)
 
-	resp, err := http.Get(url)
+	resp, err := client.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("error getting jeopardy questions: %v", err)
 	}

--- a/jeopardy/jeopardy_test.go
+++ b/jeopardy/jeopardy_test.go
@@ -1,0 +1,160 @@
+package jeopardy
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/highsaltlevels/saltbot/util"
+)
+
+const expectedError = "expect me"
+
+type MockFailedReadCloser struct {
+	io.Reader
+	io.Closer
+}
+
+func (rc MockFailedReadCloser) Read(p []byte) (n int, err error) {
+	return 0, errors.New(expectedError)
+}
+
+func (rc MockFailedReadCloser) Close() error {
+	return errors.New(expectedError)
+}
+
+type MockHttpClient struct {
+	util.HttpClientInterface
+
+	// The response to return if successful
+	jeopardyResponse interface{}
+
+	// Used to determine if the mock client should return error or not
+	expectError bool
+
+	// Used to determine if mock client should return object that can't be read
+	expectIOError bool
+
+	// The response code to be used in the http response object
+	responseCode int
+}
+
+func (c *MockHttpClient) Get(url string) (*http.Response, error) {
+	if c.expectError {
+		return nil, errors.New(expectedError)
+	}
+
+	if c.expectIOError {
+		return &http.Response{
+			StatusCode: c.responseCode,
+			Body:       MockFailedReadCloser{},
+		}, nil
+	}
+
+	data, _ := json.Marshal(c.jeopardyResponse)
+
+	return &http.Response{
+		StatusCode: c.responseCode,
+		Body:       io.NopCloser(strings.NewReader(string(data))),
+	}, nil
+}
+
+func TestGet(t *testing.T) {
+	tests := []struct {
+		name             string
+		jeopardyResponse interface{}
+		getResponseCode  int
+		// Should the client return an error instead. Omitting == false
+		shouldClientError bool
+		// Should the ReadCloser response body error. Omitting == false
+		shouldReadCloserError bool
+		expectedRespStrings   []string
+		expectedError         error
+	}{
+		{
+			name: "Test successful jeopardy question fetch",
+			jeopardyResponse: JeopardyResponse{
+				Title: "expected title",
+				Clues: []Clue{
+					Clue{
+						Question: "expected question 1",
+						Answer:   "expected answer 1",
+					},
+					Clue{
+						Question: "expected question 2",
+						Answer:   "expected answer 2",
+					},
+				},
+			},
+			getResponseCode: http.StatusOK,
+			expectedRespStrings: []string{
+				"expected title",
+				"expected question 1",
+				"expected answer 1",
+				"expected question 2",
+				"expected answer 2",
+			},
+			expectedError: nil,
+		},
+		{
+			name:              "Test failed jeopardy question fetch",
+			jeopardyResponse:  JeopardyResponse{},
+			getResponseCode:   http.StatusOK,
+			shouldClientError: true,
+			expectedError:     errors.New("error getting jeopardy question"),
+		},
+		{
+			name:                  "Test failed readon jeopardy response body",
+			jeopardyResponse:      JeopardyResponse{},
+			getResponseCode:       http.StatusOK,
+			shouldReadCloserError: true,
+			expectedError:         errors.New("failed to read jeopardy response"),
+		},
+		{
+			name:             "Test jeopardy returns non-200 statuscode",
+			jeopardyResponse: JeopardyResponse{},
+			getResponseCode:  http.StatusInternalServerError,
+			expectedError:    fmt.Errorf("got %d status code getting jeopardy question", http.StatusInternalServerError),
+		},
+		{
+			name:             "Test jeopardy failed unmarshaling response",
+			jeopardyResponse: []byte("you can't unmarshal me :)"),
+			getResponseCode:  http.StatusOK,
+			expectedError:    errors.New("failed to unmarshal jeopardy response"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client = &MockHttpClient{
+				expectError:      tt.shouldClientError,
+				expectIOError:    tt.shouldReadCloserError,
+				responseCode:     tt.getResponseCode,
+				jeopardyResponse: tt.jeopardyResponse,
+			}
+
+			msg, err := Get()
+			if tt.expectedError != nil {
+				if err == nil {
+					t.Errorf("expected error '%v' to be returned but was nil", tt.expectedError)
+				}
+				if !strings.Contains(err.Error(), tt.expectedError.Error()) {
+					t.Errorf("expected error '%v', but got error '%v'", tt.expectedError, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error but got error: '%v'", err)
+				}
+				for _, resp := range tt.expectedRespStrings {
+					if !strings.Contains(msg.Content, resp) {
+						t.Errorf("expected message: '%s', but got '%s'", resp, msg.Content)
+					}
+				}
+			}
+		})
+	}
+}

--- a/poll/poll.go
+++ b/poll/poll.go
@@ -22,7 +22,7 @@ const helpMessage string = ("```How to set a poll:\n" +
 	"second)```")
 
 const voteHelpMessage string = ("```To vote on a poll, use \"!vote <poll id> " +
-	"<choice num>\". For example: \"!vote dd32251a 1\"'''")
+	"<choice num>\". For example: \"!vote dd32251a 1\"```")
 
 func parsePoll(args []string, m *discordgo.MessageCreate) (*cache.Poll, error) {
 	prompt := strings.Replace(strings.Replace(args[0], "!poll", "", 1), "!p", "", 1)

--- a/poll/poll_test.go
+++ b/poll/poll_test.go
@@ -1,0 +1,296 @@
+package poll
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/highsaltlevels/saltbot/cache"
+	"github.com/highsaltlevels/saltbot/testutil"
+)
+
+func TestCreate(t *testing.T) {
+	tests := []struct {
+		name             string
+		cache            *cache.ConfigMapCache
+		client           kubernetes.Interface
+		commandStr       string
+		expectedMessages []string
+		expectedError    error
+	}{
+		{
+			name:       "Test creating a poll successfully",
+			cache:      &cache.ConfigMapCache{},
+			client:     &testutil.MockK8sClient{},
+			commandStr: "!poll prompt ; choice1 ; choice2 ; ends in 1 minute",
+			expectedMessages: []string{
+				"prompt",
+				"choice1",
+				"choice2",
+				"Type or DM me \"!vote",
+			},
+			expectedError: nil,
+		},
+		{
+			name:       "Test creating a poll successfully using short form",
+			cache:      &cache.ConfigMapCache{},
+			client:     &testutil.MockK8sClient{},
+			commandStr: "!p prompt ; choice1 ; choice2 ; ends in 1 minute",
+			expectedMessages: []string{
+				"prompt",
+				"choice1",
+				"choice2",
+				"Type or DM me \"!vote",
+			},
+			expectedError: nil,
+		},
+		{
+			name:             "Test sending not enough args",
+			cache:            &cache.ConfigMapCache{},
+			client:           &testutil.MockK8sClient{},
+			commandStr:       "!poll",
+			expectedMessages: []string{helpMessage},
+			expectedError:    nil,
+		},
+		{
+			name:             "Test poll help",
+			cache:            &cache.ConfigMapCache{},
+			client:           &testutil.MockK8sClient{},
+			commandStr:       "!poll help",
+			expectedMessages: []string{helpMessage},
+			expectedError:    nil,
+		},
+		{
+			name:             "Test missing ends",
+			cache:            &cache.ConfigMapCache{},
+			client:           &testutil.MockK8sClient{},
+			commandStr:       "!poll prompt ; choice1 ; choice2 ; in 1 minute",
+			expectedMessages: []string{helpMessage},
+			expectedError:    nil,
+		},
+		{
+			name:             "Test missing in",
+			cache:            &cache.ConfigMapCache{},
+			client:           &testutil.MockK8sClient{},
+			commandStr:       "!poll prompt ; choice1 ; choice2 ; ends 1 minute",
+			expectedMessages: []string{helpMessage},
+			expectedError:    nil,
+		},
+		{
+			name:             "Test not enough choice args",
+			cache:            &cache.ConfigMapCache{},
+			client:           &testutil.MockK8sClient{},
+			commandStr:       "!poll prompt ; choice1 ; ends in 1 minute",
+			expectedMessages: []string{helpMessage},
+			expectedError:    nil,
+		},
+		{
+			name:             "Test cannot add poll",
+			cache:            &cache.ConfigMapCache{},
+			client:           &testutil.MockErrorK8sClient{},
+			commandStr:       "!poll prompt ; choice1 ; choice2 ; ends in 1 minute",
+			expectedMessages: []string{},
+			expectedError:    errors.New("error adding poll to k8s"),
+		},
+		{
+			name:             "Test invalid expiry",
+			cache:            &cache.ConfigMapCache{},
+			client:           &testutil.MockK8sClient{},
+			commandStr:       "!poll prompt ; choice1 ; choice2 ; ends in 1 minit",
+			expectedMessages: []string{helpMessage},
+			expectedError:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache.Client = tt.client.(kubernetes.Interface)
+			cache.Cache = tt.cache
+			msg := discordgo.MessageCreate{
+				Message: &discordgo.Message{
+					Content:   tt.commandStr,
+					ChannelID: "1234",
+					Author: &discordgo.User{
+						ID: "1234",
+					},
+				},
+			}
+
+			resp, err := Create(&msg)
+			if tt.expectedError == nil {
+				if err != nil {
+					t.Fatalf("expected nil error but got: %v", err)
+				}
+
+				for _, expectedMessage := range tt.expectedMessages {
+					if !strings.Contains(resp.Content, expectedMessage) {
+						t.Errorf("expected: '%s' to be in: '%s'", expectedMessage, resp.Content)
+					}
+				}
+
+			} else {
+				if err == nil {
+					t.Fatalf("expected error: '%v', but got nil error", tt.expectedError)
+				}
+
+				if !strings.Contains(err.Error(), tt.expectedError.Error()) {
+					t.Errorf("expected error: '%v', but got: '%v'", tt.expectedError, err)
+				}
+			}
+		})
+	}
+}
+
+func TestVote(t *testing.T) {
+	tests := []struct {
+		name            string
+		polls           map[string]cache.Poll
+		commandStr      string
+		client          kubernetes.Interface
+		expectedMessage string
+		expectedError   error
+	}{
+		{
+			name: "Test vote successfully",
+			polls: map[string]cache.Poll{
+				"1234": cache.Poll{
+					Choices: []string{
+						"choice1",
+					},
+				},
+			},
+			commandStr:      "!vote 1234 1",
+			client:          &testutil.MockK8sClient{},
+			expectedMessage: "You have voted for choice1",
+			expectedError:   nil,
+		},
+		{
+			name: "Test vote successfully using short form",
+			polls: map[string]cache.Poll{
+				"1234": cache.Poll{
+					Choices: []string{
+						"choice1",
+					},
+				},
+			},
+			commandStr:      "!v 1234 1",
+			client:          &testutil.MockK8sClient{},
+			expectedMessage: "You have voted for choice1",
+			expectedError:   nil,
+		},
+		{
+			name:            "Test vote not enough args",
+			polls:           map[string]cache.Poll{},
+			commandStr:      "!v 1234",
+			client:          &testutil.MockK8sClient{},
+			expectedMessage: voteHelpMessage,
+			expectedError:   nil,
+		},
+		{
+			name:            "Test vote invalid arg",
+			polls:           map[string]cache.Poll{},
+			commandStr:      "!v 1234 foo",
+			client:          &testutil.MockK8sClient{},
+			expectedMessage: voteHelpMessage,
+			expectedError:   nil,
+		},
+		{
+			name:            "Test vote poll doesn't exist",
+			polls:           map[string]cache.Poll{},
+			commandStr:      "!v 1234 1",
+			client:          &testutil.MockK8sClient{},
+			expectedMessage: "Poll 1234 does not exist!",
+			expectedError:   nil,
+		},
+		{
+			name: "Test vote invalid choice number",
+			polls: map[string]cache.Poll{
+				"1234": cache.Poll{
+					Choices: []string{
+						"choice1",
+					},
+				},
+			},
+			commandStr:      "!v 1234 2",
+			client:          &testutil.MockK8sClient{},
+			expectedMessage: "No such choice number: 2",
+			expectedError:   nil,
+		},
+		{
+			name: "Test vote selecting different choice",
+			polls: map[string]cache.Poll{
+				"1234": cache.Poll{
+					Choices: []string{
+						"choice1",
+						"choice2",
+					},
+					Votes: map[string][]interface{}{
+						"0": []interface{}{
+							"user",
+							"other user",
+						},
+					},
+				},
+			},
+			commandStr:      "!vote 1234 2",
+			client:          &testutil.MockK8sClient{},
+			expectedMessage: "You have voted for choice2",
+			expectedError:   nil,
+		},
+		{
+			name: "Test vote kubernetes threw error",
+			polls: map[string]cache.Poll{
+				"1234": cache.Poll{
+					Choices: []string{
+						"choice1",
+					},
+				},
+			},
+			commandStr:      "!v 1234 1",
+			client:          &testutil.MockErrorK8sClient{},
+			expectedMessage: "",
+			expectedError:   errors.New("failed to update poll"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := discordgo.MessageCreate{
+				Message: &discordgo.Message{
+					Content:   tt.commandStr,
+					ChannelID: "1234",
+					Author: &discordgo.User{
+						ID:       "1234",
+						Username: "user",
+					},
+				},
+			}
+
+			cache.Cache = cache.NewInMemConfigMapCache(tt.polls, map[string]cache.Reminder{})
+			cache.Client = tt.client.(kubernetes.Interface)
+			resp, err := Vote(&msg)
+
+			if tt.expectedError == nil {
+				if err != nil {
+					t.Fatalf("expected nil error but got: %v", err)
+				}
+
+				if !strings.Contains(resp.Content, tt.expectedMessage) {
+					t.Errorf("expected: '%s' to be in: '%s'", tt.expectedMessage, resp.Content)
+				}
+
+			} else {
+				if err == nil {
+					t.Fatalf("expected error: '%v', but got nil error", tt.expectedError)
+				}
+
+				if !strings.Contains(err.Error(), tt.expectedError.Error()) {
+					t.Errorf("expected error: '%v', but got: '%v'", tt.expectedError, err)
+				}
+			}
+		})
+	}
+}

--- a/reminder/reminder_test.go
+++ b/reminder/reminder_test.go
@@ -1,0 +1,195 @@
+package reminder
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/highsaltlevels/saltbot/cache"
+	"github.com/highsaltlevels/saltbot/testutil"
+)
+
+const expectedError string = "expect me"
+
+func TestHandle(t *testing.T) {
+	tests := []struct {
+		name            string
+		reminders       map[string]cache.Reminder
+		commandStr      string
+		client          kubernetes.Interface
+		expectedMessage string
+		expectedError   error
+	}{
+		{
+			name:            "test set reminder",
+			reminders:       map[string]cache.Reminder{},
+			commandStr:      "!remind set do something in 1 second",
+			client:          &testutil.MockK8sClient{},
+			expectedMessage: "Created reminder with id:",
+		},
+		{
+			name:            "test set reminder missing 'in'",
+			reminders:       map[string]cache.Reminder{},
+			commandStr:      "!remind set do something 1 second",
+			client:          &testutil.MockK8sClient{},
+			expectedMessage: helpMessage,
+		},
+		{
+			name:            "test set reminder invalid expiry",
+			reminders:       map[string]cache.Reminder{},
+			commandStr:      "!remind set do something in 1 minit",
+			client:          &testutil.MockK8sClient{},
+			expectedMessage: helpMessage,
+		},
+		{
+			name:            "test asking for help",
+			reminders:       map[string]cache.Reminder{},
+			commandStr:      "!remind help",
+			client:          &testutil.MockK8sClient{},
+			expectedMessage: helpMessage,
+		},
+		{
+			name:            "test not enough args",
+			reminders:       map[string]cache.Reminder{},
+			commandStr:      "!remind",
+			client:          &testutil.MockK8sClient{},
+			expectedMessage: helpMessage,
+		},
+		{
+			name:          "test adding to k8s returns error",
+			reminders:     map[string]cache.Reminder{},
+			commandStr:    "!remind set do something in 1 second",
+			client:        &testutil.MockErrorK8sClient{},
+			expectedError: errors.New("error adding reminder to k8s"),
+		},
+		{
+			name:            "test invalid command",
+			reminders:       map[string]cache.Reminder{},
+			commandStr:      "!remind something else",
+			client:          &testutil.MockK8sClient{},
+			expectedMessage: helpMessage,
+		},
+		{
+			name: "test list reminders",
+			reminders: map[string]cache.Reminder{
+				"1234": cache.Reminder{
+					Author:  "1234",
+					Channel: "1234",
+					Expiry:  12345,
+					Message: "foo",
+					Id:      "1234",
+				},
+				"5678": cache.Reminder{
+					Author:  "1234",
+					Channel: "1234",
+					Expiry:  12345,
+					Message: "bar",
+					Id:      "5687",
+				},
+			},
+			commandStr: "!remind list",
+			client:     &testutil.MockK8sClient{},
+			// "on" will not be in the message if there's no reminders
+			expectedMessage: "on",
+		},
+		{
+			name: "test list reminders mismatching author",
+			reminders: map[string]cache.Reminder{
+				"1234": cache.Reminder{
+					Author:  "not the expected one",
+					Channel: "1234",
+					Expiry:  12345,
+					Message: "foo",
+					Id:      "1234",
+				},
+				"5678": cache.Reminder{
+					Author:  "not the expected one",
+					Channel: "1234",
+					Expiry:  12345,
+					Message: "bar",
+					Id:      "5687",
+				},
+			},
+			commandStr:      "!remind list",
+			client:          &testutil.MockK8sClient{},
+			expectedMessage: "```Reminders:\n```",
+		},
+		{
+			name:            "test list reminders empty cache",
+			reminders:       map[string]cache.Reminder{},
+			commandStr:      "!remind list",
+			client:          &testutil.MockK8sClient{},
+			expectedMessage: "```Reminders:\n```",
+		},
+		{
+			name: "test delete reminder successfully",
+			reminders: map[string]cache.Reminder{
+				"1234": cache.Reminder{
+					Author:  "1234",
+					Channel: "1234",
+					Expiry:  12345,
+					Message: "foo",
+					Id:      "1234",
+				},
+			},
+			commandStr:      "!remind delete 1234",
+			client:          &testutil.MockK8sClient{},
+			expectedMessage: "```Deleted reminder 1234```",
+		},
+		{
+			name:            "test delete not enough args",
+			reminders:       map[string]cache.Reminder{},
+			commandStr:      "!remind delete",
+			client:          &testutil.MockK8sClient{},
+			expectedMessage: "To delete a reminder, you must specify the id",
+		},
+		{
+			name:            "test delete reminder doesn't exist",
+			reminders:       map[string]cache.Reminder{},
+			commandStr:      "!remind delete 1234",
+			client:          &testutil.MockK8sClient{},
+			expectedMessage: "Either that reminder doesn't exist or you don't",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := discordgo.MessageCreate{
+				Message: &discordgo.Message{
+					Content:   tt.commandStr,
+					ChannelID: "1234",
+					Author: &discordgo.User{
+						ID:       "1234",
+						Username: "user",
+					},
+				},
+			}
+			cache.Cache = cache.NewInMemConfigMapCache(map[string]cache.Poll{}, tt.reminders)
+			cache.Client = tt.client.(kubernetes.Interface)
+
+			resp, err := Handle(&msg)
+
+			if tt.expectedError == nil {
+				if err != nil {
+					t.Fatalf("expected nil error but got: %v", err)
+				}
+
+				if !strings.Contains(resp.Content, tt.expectedMessage) {
+					t.Errorf("expected: '%s' to be in: '%s'", tt.expectedMessage, resp.Content)
+				}
+
+			} else {
+				if err == nil {
+					t.Fatalf("expected error: '%v', but got nil error", tt.expectedError)
+				}
+
+				if !strings.Contains(err.Error(), tt.expectedError.Error()) {
+					t.Errorf("expected error: '%v', but got: '%v'", tt.expectedError, err)
+				}
+			}
+		})
+	}
+}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+mkdir -p /tmp/saltbot
+go test -coverprofile=coverage.out ./... && go tool cover -html=coverage.out -o /tmp/saltbot/result.html

--- a/saltbot.go
+++ b/saltbot.go
@@ -29,17 +29,17 @@ func main() {
 	var err error
 	time.Local, err = time.LoadLocation("US/Eastern")
 	if err != nil {
-		log.Fatalf("failed to load locale: %w", err)
+		log.Fatalf("failed to load locale: %v", err)
 	}
 
 	session, err := discordgo.New("Bot " + token)
 	if err != nil {
-		log.Fatalf("failed to initialize saltbot: %w", err)
+		log.Fatalf("failed to initialize saltbot: %v", err)
 	}
 
 	err = session.Open()
 	if err != nil {
-		log.Fatalf("failed to open discord socket: %w", err)
+		log.Fatalf("failed to open discord socket: %v", err)
 	}
 	defer session.Close()
 

--- a/saltbot.go
+++ b/saltbot.go
@@ -43,11 +43,14 @@ func main() {
 	}
 	defer session.Close()
 
+	log.Println("initializing poll/reminder cache")
+	cache.NewConfigMapCache()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	log.Println("initializing messenger")
-	checker := expirychecker.NewPoller(session, cache.Cache, ctx)
+	checker := expirychecker.NewPoller(session, ctx)
 	go checker.Loop()
 
 	log.Println("registering message handlers")

--- a/testutil/mocks.go
+++ b/testutil/mocks.go
@@ -1,0 +1,77 @@
+package testutil
+
+import (
+	"context"
+	"errors"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+const ExpectedError string = "expect me"
+
+type MockConfigMapClient struct {
+	corev1.ConfigMapInterface
+}
+
+func (m MockConfigMapClient) Create(ctx context.Context, configMap *v1.ConfigMap, opts metav1.CreateOptions) (*v1.ConfigMap, error) {
+	return nil, nil
+}
+
+func (m MockConfigMapClient) Update(ctx context.Context, configMap *v1.ConfigMap, opts metav1.UpdateOptions) (*v1.ConfigMap, error) {
+	return nil, nil
+}
+
+func (m MockConfigMapClient) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	return nil
+}
+
+type MockCoreV1 struct {
+	corev1.CoreV1Interface
+}
+
+func (m MockCoreV1) ConfigMaps(namespace string) corev1.ConfigMapInterface {
+	return MockConfigMapClient{}
+}
+
+type MockK8sClient struct {
+	kubernetes.Interface
+}
+
+func (m MockK8sClient) CoreV1() corev1.CoreV1Interface {
+	return MockCoreV1{}
+}
+
+type MockErrorConfigMapClient struct {
+	corev1.ConfigMapInterface
+}
+
+func (m MockErrorConfigMapClient) Create(ctx context.Context, configMap *v1.ConfigMap, opts metav1.CreateOptions) (*v1.ConfigMap, error) {
+	return nil, errors.New(ExpectedError)
+}
+
+func (m MockErrorConfigMapClient) Update(ctx context.Context, configMap *v1.ConfigMap, opts metav1.UpdateOptions) (*v1.ConfigMap, error) {
+	return nil, errors.New(ExpectedError)
+}
+
+func (m MockErrorConfigMapClient) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	return errors.New(ExpectedError)
+}
+
+type MockErrorCoreV1 struct {
+	corev1.CoreV1Interface
+}
+
+func (m MockErrorCoreV1) ConfigMaps(namespace string) corev1.ConfigMapInterface {
+	return MockErrorConfigMapClient{}
+}
+
+type MockErrorK8sClient struct {
+	kubernetes.Interface
+}
+
+func (m MockErrorK8sClient) CoreV1() corev1.CoreV1Interface {
+	return MockErrorCoreV1{}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -2,10 +2,16 @@ package util
 
 import (
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
 )
+
+// Client interface for testing of 3rd party web services like youtube, giphy, jeopardy, etc...
+type HttpClientInterface interface {
+	Get(string) (*http.Response, error)
+}
 
 var unitDict map[string]int = map[string]int{
 	"year":    31536000,

--- a/util/util.go
+++ b/util/util.go
@@ -76,13 +76,3 @@ func TimeFromExpiry(expiry int64) string {
 	expiryTime := time.Unix(expiry, 0)
 	return expiryTime.Format(time.RFC1123)
 }
-
-func Contains(s []string, str string) bool {
-	for _, v := range s {
-		if v == str {
-			return true
-		}
-	}
-
-	return false
-}

--- a/youtube/youtube_test.go
+++ b/youtube/youtube_test.go
@@ -1,0 +1,221 @@
+package youtube
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/highsaltlevels/saltbot/util"
+)
+
+const expectedError = "expect me"
+
+type MockFailedReadCloser struct {
+	io.Reader
+	io.Closer
+}
+
+func (rc MockFailedReadCloser) Read(p []byte) (n int, err error) {
+	return 0, errors.New(expectedError)
+}
+
+func (rc MockFailedReadCloser) Close() error {
+	return errors.New(expectedError)
+}
+
+type MockHttpClient struct {
+	util.HttpClientInterface
+
+	// The response to return if successful
+	youtubeResponse interface{}
+
+	// Used to determine if the mock client should return error or not
+	expectError bool
+
+	// Used to determine if mock client should return object that can't be read
+	expectIOError bool
+
+	// The response code to be used in the http response object
+	responseCode int
+}
+
+func (c *MockHttpClient) Get(url string) (*http.Response, error) {
+	if c.expectError {
+		return nil, errors.New(expectedError)
+	}
+
+	if c.expectIOError {
+		return &http.Response{
+			StatusCode: c.responseCode,
+			Body:       MockFailedReadCloser{},
+		}, nil
+	}
+
+	data, _ := json.Marshal(c.youtubeResponse)
+
+	return &http.Response{
+		StatusCode: c.responseCode,
+		Body:       io.NopCloser(strings.NewReader(string(data))),
+	}, nil
+}
+
+func TestGet(t *testing.T) {
+	tests := []struct {
+		name            string
+		commandStr      string
+		youtubeResponse interface{}
+		getResponseCode int
+		// Should the client return an error instead. Omitting == false
+		shouldClientError bool
+		// Should the ReadCloser response body error. Omitting == false
+		shouldReadCloserError bool
+		expectedResponse      string
+		expectedError         error
+	}{
+		{
+			name:       "Test successful youtube video fetch",
+			commandStr: "!youtube query",
+			youtubeResponse: YoutubeResponse{
+				Items: []YoutubeVideo{
+					YoutubeVideo{
+						Id: YoutubeId{
+							VideoId: "foo",
+						},
+					},
+				},
+			},
+			getResponseCode:  http.StatusOK,
+			expectedResponse: "https://www.youtube.com/watch?v=foo",
+			expectedError:    nil,
+		},
+		{
+			name:       "Test successful youtube video fetch with short form",
+			commandStr: "!y query",
+			youtubeResponse: YoutubeResponse{
+				Items: []YoutubeVideo{
+					YoutubeVideo{
+						Id: YoutubeId{
+							VideoId: "foo",
+						},
+					},
+				},
+			},
+			getResponseCode:  http.StatusOK,
+			expectedResponse: "https://www.youtube.com/watch?v=foo",
+			expectedError:    nil,
+		},
+		{
+			name:       "Test successful youtube video fetch with specific index",
+			commandStr: "!youtube query -i 0",
+			youtubeResponse: YoutubeResponse{
+				Items: []YoutubeVideo{
+					YoutubeVideo{
+						Id: YoutubeId{
+							VideoId: "foo",
+						},
+					},
+				},
+			},
+			getResponseCode:  http.StatusOK,
+			expectedResponse: "https://www.youtube.com/watch?v=foo",
+			expectedError:    nil,
+		},
+		{
+			name:              "Test failed youtube video fetch",
+			commandStr:        "!youtube query",
+			youtubeResponse:   YoutubeResponse{},
+			getResponseCode:   http.StatusOK,
+			shouldClientError: true,
+			expectedError:     errors.New(expectedError),
+		},
+		{
+			name:            "Test youtube video fetch returns non-200",
+			commandStr:      "!youtube query",
+			youtubeResponse: YoutubeResponse{},
+			getResponseCode: http.StatusInternalServerError,
+			expectedError:   fmt.Errorf("received status code %d from youtube", http.StatusInternalServerError),
+		},
+		{
+			name:       "Test successful youtube video fetch but 0 videos returned",
+			commandStr: "!youtube query",
+			youtubeResponse: YoutubeResponse{
+				Items: []YoutubeVideo{},
+			},
+			getResponseCode:  http.StatusOK,
+			expectedResponse: "```No videos for that query :(```",
+			expectedError:    nil,
+		},
+		{
+			name:             "Test invalid command string",
+			commandStr:       "!youtube",
+			youtubeResponse:  YoutubeResponse{},
+			getResponseCode:  http.StatusOK,
+			expectedResponse: "```Must specify a query like: \"!youtube dog\"```",
+			expectedError:    nil,
+		},
+		{
+			name:             "Test pick video by index with negative index",
+			commandStr:       "!youtube -i -1",
+			youtubeResponse:  YoutubeResponse{},
+			getResponseCode:  http.StatusOK,
+			expectedResponse: "```Must use a valid number between 0 and 14```",
+			expectedError:    nil,
+		},
+		{
+			name:             "Test pick video by index with disallowed index",
+			commandStr:       "!youtube -i 15",
+			youtubeResponse:  YoutubeResponse{},
+			getResponseCode:  http.StatusOK,
+			expectedResponse: "```Must use a valid number between 0 and 14```",
+			expectedError:    nil,
+		},
+		{
+			name:            "Test youtube video fetch unmarshalable response",
+			commandStr:      "!youtube query",
+			youtubeResponse: []byte("this can't be marshaled"),
+			getResponseCode: http.StatusOK,
+			expectedError:   errors.New("failed to unmarshal youtube response"),
+		},
+		{
+			name:                  "Test youtube video fetch unreadable response",
+			commandStr:            "!youtube query",
+			youtubeResponse:       YoutubeResponse{},
+			getResponseCode:       http.StatusOK,
+			shouldReadCloserError: true,
+			expectedError:         errors.New("failed to read youtube resp"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client = &MockHttpClient{
+				expectError:     tt.shouldClientError,
+				expectIOError:   tt.shouldReadCloserError,
+				responseCode:    tt.getResponseCode,
+				youtubeResponse: tt.youtubeResponse,
+			}
+
+			msg, err := Get(tt.commandStr)
+			if tt.expectedError != nil {
+				if err == nil {
+					t.Errorf("expected error '%v' to be returned but was nil", tt.expectedError)
+				}
+				if !strings.Contains(err.Error(), tt.expectedError.Error()) {
+					t.Errorf("expected error '%v', but got error '%v'", tt.expectedError, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error but got error: '%v'", err)
+				}
+				if msg.Content != tt.expectedResponse {
+					t.Errorf("expected message: '%s', but got '%s'", tt.expectedResponse, msg.Content)
+				}
+			}
+		})
+
+	}
+}


### PR DESCRIPTION
# What/Why
I thought it would be better to just straight up shove the marshaled json directly into the configmap instead of going with the whole custom resource route or the sus json building with strings. As soon as I deploy this into the cluster, I need to port all of the existing reminders to the new format.

Also, I added a _ton_ of tests. I don't think it's possible to get a full 100% coverage without doing some incredibly sus things. Mainly because it's difficult to test the kubernetes-specific components. But I did add a helper script.

Resolves #33 
Resolves #34 
